### PR TITLE
Implement VAE loss and add beta experiments

### DIFF
--- a/VAE_MNIST.ipynb
+++ b/VAE_MNIST.ipynb
@@ -1,1279 +1,1363 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "toc_visible": true,
-      "gpuType": "A100"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "E4k99EyIMI7P"
+   },
+   "source": [
+    "## Environment\n"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Environment\n"
-      ],
-      "metadata": {
-        "id": "E4k99EyIMI7P"
-      }
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
     },
+    "id": "HwU-XaAyyNkH",
+    "outputId": "64ad974b-ddd8-46df-908d-e9489ba3f478"
+   },
+   "outputs": [
     {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "HwU-XaAyyNkH",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "64ad974b-ddd8-46df-908d-e9489ba3f478"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Using device: cuda\n"
-          ]
-        }
-      ],
-      "source": [
-        "import torch\n",
-        "import torch.nn as nn\n",
-        "import torch.nn.functional as F\n",
-        "import torchvision\n",
-        "from torch.utils.data import DataLoader\n",
-        "from torchvision import datasets, transforms\n",
-        "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
-        "from sklearn.decomposition import PCA\n",
-        "from scipy.stats import wasserstein_distance, ks_2samp\n",
-        "from scipy import stats\n",
-        "from tqdm import tqdm\n",
-        "\n",
-        "torch.manual_seed(42)\n",
-        "np.random.seed(42)\n",
-        "\n",
-        "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
-        "print(f\"Using device: {device}\")\n",
-        "\n",
-        "def plot_results(images, nrow=10, title=None):\n",
-        "    images = (images.cpu().detach().clone() * 0.5 + 0.5).clamp(0, 1)\n",
-        "    grid = torchvision.utils.make_grid(images, nrow=nrow, padding=1, normalize=False)\n",
-        "    plt.figure(figsize=(10, (images.size(0) // nrow + 1) * 1.0), dpi=300)\n",
-        "    np_grid = grid.permute(1, 2, 0).numpy()\n",
-        "    plt.imshow(np_grid)\n",
-        "    plt.axis(\"off\")\n",
-        "    if title is not None:\n",
-        "        plt.title(title, fontsize=16)\n",
-        "    plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## VAE Model"
-      ],
-      "metadata": {
-        "id": "cqCmI6RyMPku"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "class PreActResidualBlock(nn.Module):\n",
-        "    \"\"\"Pre-activation ResBlock: GN -> SiLU -> Conv -> GN -> SiLU -> Conv + shortcut.\"\"\"\n",
-        "    def __init__(self, in_channels, out_channels, groups=8, dropout=0.1):\n",
-        "        super().__init__()\n",
-        "        self.gn1 = nn.GroupNorm(groups, in_channels)\n",
-        "        self.act1 = nn.SiLU()\n",
-        "        self.conv1 = nn.Conv2d(in_channels, out_channels, 3, padding=1, bias=False)\n",
-        "\n",
-        "        self.gn2 = nn.GroupNorm(groups, out_channels)\n",
-        "        self.act2 = nn.SiLU()\n",
-        "        self.dropout = nn.Dropout2d(dropout) if dropout > 0 else nn.Identity()\n",
-        "        self.conv2 = nn.Conv2d(out_channels, out_channels, 3, padding=1, bias=False)\n",
-        "\n",
-        "        self.shortcut = (\n",
-        "            nn.Conv2d(in_channels, out_channels, 1, bias=False)\n",
-        "            if in_channels != out_channels else nn.Identity()\n",
-        "        )\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        out = self.conv1(self.act1(self.gn1(x)))\n",
-        "        out = self.conv2(self.dropout(self.act2(self.gn2(out))))\n",
-        "        return out + self.shortcut(x)\n",
-        "\n",
-        "\n",
-        "class ConvVAE(nn.Module):\n",
-        "    def __init__(self, latent_dim=128, img_channels=1, groups=8, dropout=0.1,\n",
-        "                 out_activation=\"tanh\"):  # out_activation: \"tanh\" or \"sigmoid\"\n",
-        "        super().__init__()\n",
-        "        self.latent_dim = latent_dim\n",
-        "        self.img_channels = img_channels\n",
-        "        self.out_activation = out_activation\n",
-        "\n",
-        "        # ----------------\n",
-        "        # Encoder: 28 -> 14 -> 7 -> 4\n",
-        "        # ----------------\n",
-        "        self.enc = nn.Sequential(\n",
-        "            # 28 -> 14\n",
-        "            nn.Conv2d(img_channels, 32, 3, stride=2, padding=1, bias=False),\n",
-        "            PreActResidualBlock(32, 32, groups=groups, dropout=dropout),\n",
-        "\n",
-        "            # 14 -> 7\n",
-        "            nn.Conv2d(32, 64, 3, stride=2, padding=1, bias=False),\n",
-        "            PreActResidualBlock(64, 64, groups=groups, dropout=dropout),\n",
-        "\n",
-        "            # 7 -> 4\n",
-        "            nn.Conv2d(64, 128, 3, stride=2, padding=1, bias=False),\n",
-        "            PreActResidualBlock(128, 128, groups=groups, dropout=dropout),\n",
-        "        )\n",
-        "        self.mid = PreActResidualBlock(128, 128, groups=groups, dropout=dropout)\n",
-        "\n",
-        "        self.flatten_dim = 128 * 4 * 4\n",
-        "        self.fc_mu = nn.Linear(self.flatten_dim, latent_dim)\n",
-        "        self.fc_logvar = nn.Linear(self.flatten_dim, latent_dim)\n",
-        "\n",
-        "        # ----------------\n",
-        "        # Decoder: z -> 4x4 -> 7 -> 14 -> 28\n",
-        "        # ----------------\n",
-        "        self.fc_decode = nn.Linear(latent_dim, self.flatten_dim)\n",
-        "\n",
-        "        self.dec1 = nn.Sequential(\n",
-        "            # 4 -> 7  (k=3,s=2,p=1 gives 7)\n",
-        "            nn.ConvTranspose2d(128, 64, 3, stride=2, padding=1, output_padding=0, bias=False),\n",
-        "            nn.GroupNorm(groups, 64),\n",
-        "            nn.SiLU(),\n",
-        "            PreActResidualBlock(64, 64, groups=groups, dropout=dropout),\n",
-        "        )\n",
-        "        self.dec2 = nn.Sequential(\n",
-        "            # 7 -> 14\n",
-        "            nn.ConvTranspose2d(64, 32, 4, stride=2, padding=1, bias=False),\n",
-        "            nn.GroupNorm(groups, 32),\n",
-        "            nn.SiLU(),\n",
-        "            PreActResidualBlock(32, 32, groups=groups, dropout=dropout),\n",
-        "        )\n",
-        "        self.dec3 = nn.Sequential(\n",
-        "            # 14 -> 28\n",
-        "            nn.ConvTranspose2d(32, 32, 4, stride=2, padding=1, bias=False),\n",
-        "            nn.GroupNorm(groups, 32),\n",
-        "            nn.SiLU(),\n",
-        "        )\n",
-        "        self.out_conv = nn.Conv2d(32, img_channels, 3, padding=1)\n",
-        "\n",
-        "        self.apply(self._init_weights)\n",
-        "\n",
-        "    @staticmethod\n",
-        "    def _init_weights(m):\n",
-        "        if isinstance(m, (nn.Conv2d, nn.ConvTranspose2d)):\n",
-        "            nn.init.kaiming_normal_(m.weight, nonlinearity='relu')\n",
-        "            if getattr(m, 'bias', None) is not None:\n",
-        "                nn.init.zeros_(m.bias)\n",
-        "        if isinstance(m, nn.Linear):\n",
-        "            nn.init.xavier_uniform_(m.weight)\n",
-        "            if m.bias is not None:\n",
-        "                nn.init.zeros_(m.bias)\n",
-        "\n",
-        "    def encode(self, x):\n",
-        "        h = self.enc(x)\n",
-        "        h = self.mid(h)\n",
-        "        h = h.view(h.size(0), -1)\n",
-        "        mu = self.fc_mu(h)\n",
-        "        logvar = self.fc_logvar(h)\n",
-        "        return mu, logvar\n",
-        "\n",
-        "    def reparameterize(self, mu, logvar):\n",
-        "        std = torch.exp(0.5 * logvar)\n",
-        "        eps = torch.randn_like(std)\n",
-        "        return mu + eps * std\n",
-        "\n",
-        "    def decode(self, z):\n",
-        "        h = self.fc_decode(z)\n",
-        "        h = h.view(h.size(0), 128, 4, 4)\n",
-        "        h = self.dec1(h)\n",
-        "        h = self.dec2(h)\n",
-        "        h = self.dec3(h)\n",
-        "        h = self.out_conv(h)\n",
-        "        if self.out_activation == \"sigmoid\":\n",
-        "            return torch.sigmoid(h)\n",
-        "        else:\n",
-        "            return torch.tanh(h)\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        mu, logvar = self.encode(x)\n",
-        "        z = self.reparameterize(mu, logvar)\n",
-        "        recon = self.decode(z)\n",
-        "        return recon, mu, logvar\n"
-      ],
-      "metadata": {
-        "id": "smIF9UF4ILGI"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Loss Function & Training Script"
-      ],
-      "metadata": {
-        "id": "mhEB8abtMvaZ"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def vae_loss_function(recon_x, x, mu, logvar, beta=1.0):\n",
-        "    recon_loss =\n",
-        "    kld =\n",
-        "    return recon_loss + beta * kld, recon_loss, kld\n",
-        "\n",
-        "\n",
-        "def train_conv_vae(vae, train_loader, epochs=20, device='cuda', beta=1.0, lr=1e-3):\n",
-        "    vae = vae.to(device)\n",
-        "    optimizer = torch.optim.AdamW(vae.parameters(), lr=lr, weight_decay=1e-5)\n",
-        "    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)\n",
-        "\n",
-        "    print(\"Training Convolutional VAE...\")\n",
-        "    print(f\"Model parameters: {sum(p.numel() for p in vae.parameters()):,}\")\n",
-        "\n",
-        "    for epoch in range(epochs):\n",
-        "        vae.train()\n",
-        "        train_loss = 0\n",
-        "        train_recon = 0\n",
-        "        train_kld = 0\n",
-        "\n",
-        "        pbar = tqdm(train_loader, desc=f\"Epoch {epoch+1}/{epochs}\")\n",
-        "        for batch_idx, (data, _) in enumerate(pbar):\n",
-        "            data = data.to(device)\n",
-        "            optimizer.zero_grad()\n",
-        "\n",
-        "            recon_batch, mu, logvar = vae(data)\n",
-        "            loss, recon_loss, kld = vae_loss_function(recon_batch, data, mu, logvar, beta)\n",
-        "\n",
-        "            loss.backward()\n",
-        "            torch.nn.utils.clip_grad_norm_(vae.parameters(), max_norm=1.0)\n",
-        "            optimizer.step()\n",
-        "\n",
-        "            train_loss += loss.item()\n",
-        "            train_recon += recon_loss.item()\n",
-        "            train_kld += kld.item()\n",
-        "\n",
-        "            pbar.set_postfix({\n",
-        "                'loss': f'{loss.item()/len(data):.2f}',\n",
-        "                'recon': f'{recon_loss.item()/len(data):.2f}',\n",
-        "                'kld': f'{kld.item()/len(data):.2f}'\n",
-        "            })\n",
-        "\n",
-        "        n_samples = len(train_loader.dataset)\n",
-        "        avg_loss = train_loss / n_samples\n",
-        "        avg_recon = train_recon / n_samples\n",
-        "        avg_kld = train_kld / n_samples\n",
-        "\n",
-        "        scheduler.step()\n",
-        "        current_lr = optimizer.param_groups[0]['lr']\n",
-        "\n",
-        "        print(f'Epoch {epoch+1}/{epochs}:')\n",
-        "        print(f'  Total Loss: {avg_loss:.4f}')\n",
-        "        print(f'  Recon Loss: {avg_recon:.4f}')\n",
-        "        print(f'  KLD Loss:   {avg_kld:.4f}')\n",
-        "        print(f'  LR:         {current_lr:.6f}')\n",
-        "\n",
-        "    return vae"
-      ],
-      "metadata": {
-        "id": "O4anBk0VIOze"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Load MNIST Dataset"
-      ],
-      "metadata": {
-        "id": "X0zdh0W5M0Gg"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "print(\"=\"*60)\n",
-        "print(\"STEP 1: Loading MNIST Dataset\")\n",
-        "print(\"=\"*60)\n",
-        "\n",
-        "transform = transforms.Compose([\n",
-        "    transforms.ToTensor(),\n",
-        "    transforms.Normalize((0.5,), (0.5,))\n",
-        "])\n",
-        "\n",
-        "train_dataset = datasets.MNIST('./data', train=True, download=True, transform=transform)\n",
-        "train_loader = DataLoader(train_dataset, batch_size=128, shuffle=True,\n",
-        "                          num_workers=4, pin_memory=True)\n",
-        "\n",
-        "print(f\"Dataset loaded: {len(train_dataset)} training images\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "7u862w2uIgp6",
-        "outputId": "06d894fb-d6d2-417c-b44f-1709a8c8bfea"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "============================================================\n",
-            "STEP 1: Loading MNIST Dataset\n",
-            "============================================================\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "100%|██████████| 9.91M/9.91M [00:01<00:00, 4.96MB/s]\n",
-            "100%|██████████| 28.9k/28.9k [00:00<00:00, 127kB/s]\n",
-            "100%|██████████| 1.65M/1.65M [00:01<00:00, 1.25MB/s]\n",
-            "100%|██████████| 4.54k/4.54k [00:00<00:00, 12.2MB/s]"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Dataset loaded: 60000 training images\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Train and Save the Model"
-      ],
-      "metadata": {
-        "id": "TKAQ-3DVM4Hw"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "print(\"\\n\" + \"=\"*60)\n",
-        "print(\"STEP 2: Training Convolutional VAE\")\n",
-        "print(\"=\"*60)\n",
-        "\n",
-        "latent_dim = 128\n",
-        "vae = ConvVAE(latent_dim=latent_dim, img_channels=1)\n",
-        "beta = 3\n",
-        "vae = train_conv_vae(vae, train_loader, epochs=40, device=device, beta=beta, lr=1e-3)\n",
-        "\n",
-        "torch.save({\n",
-        "    'model_state_dict': vae.state_dict(),\n",
-        "    'latent_dim': latent_dim,\n",
-        "}, f'conv_vae_checkpoint_{beta}.pt')\n",
-        "print(\"\\n✓ VAE checkpoint saved!\")"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "5iCkJSC-IiSi",
-        "outputId": "4fc236a5-06d7-4f87-845e-90f92d19b6ed"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "============================================================\n",
-            "STEP 2: Training Convolutional VAE\n",
-            "============================================================\n",
-            "Training Convolutional VAE...\n",
-            "Model parameters: 1,780,545\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 1/40: 100%|██████████| 469/469 [00:08<00:00, 53.43it/s, loss=132.39, recon=90.13, kld=14.09]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 1/40:\n",
-            "  Total Loss: 2943.1498\n",
-            "  Recon Loss: 121.7197\n",
-            "  KLD Loss:   940.4768\n",
-            "  LR:         0.000998\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 2/40: 100%|██████████| 469/469 [00:06<00:00, 67.28it/s, loss=112.49, recon=71.13, kld=13.79]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 2/40:\n",
-            "  Total Loss: 122.1088\n",
-            "  Recon Loss: 77.7753\n",
-            "  KLD Loss:   14.7778\n",
-            "  LR:         0.000994\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 3/40: 100%|██████████| 469/469 [00:06<00:00, 67.59it/s, loss=115.78, recon=70.81, kld=14.99]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 3/40:\n",
-            "  Total Loss: 114.2365\n",
-            "  Recon Loss: 69.8908\n",
-            "  KLD Loss:   14.7819\n",
-            "  LR:         0.000986\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 4/40: 100%|██████████| 469/469 [00:06<00:00, 69.27it/s, loss=108.67, recon=63.52, kld=15.05]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 4/40:\n",
-            "  Total Loss: 110.6938\n",
-            "  Recon Loss: 66.2842\n",
-            "  KLD Loss:   14.8032\n",
-            "  LR:         0.000976\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 5/40: 100%|██████████| 469/469 [00:06<00:00, 68.73it/s, loss=103.77, recon=59.71, kld=14.68]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 5/40:\n",
-            "  Total Loss: 108.0681\n",
-            "  Recon Loss: 63.5542\n",
-            "  KLD Loss:   14.8380\n",
-            "  LR:         0.000962\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 6/40: 100%|██████████| 469/469 [00:06<00:00, 68.48it/s, loss=112.30, recon=66.08, kld=15.41]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 6/40:\n",
-            "  Total Loss: 106.2030\n",
-            "  Recon Loss: 61.6316\n",
-            "  KLD Loss:   14.8571\n",
-            "  LR:         0.000946\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 7/40: 100%|██████████| 469/469 [00:06<00:00, 69.01it/s, loss=104.75, recon=61.30, kld=14.48]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 7/40:\n",
-            "  Total Loss: 104.6890\n",
-            "  Recon Loss: 60.1469\n",
-            "  KLD Loss:   14.8474\n",
-            "  LR:         0.000926\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 8/40: 100%|██████████| 469/469 [00:06<00:00, 67.49it/s, loss=107.79, recon=62.64, kld=15.05]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 8/40:\n",
-            "  Total Loss: 103.3347\n",
-            "  Recon Loss: 58.7162\n",
-            "  KLD Loss:   14.8728\n",
-            "  LR:         0.000905\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 9/40: 100%|██████████| 469/469 [00:06<00:00, 68.33it/s, loss=101.81, recon=58.25, kld=14.52]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 9/40:\n",
-            "  Total Loss: 102.2517\n",
-            "  Recon Loss: 57.5809\n",
-            "  KLD Loss:   14.8903\n",
-            "  LR:         0.000880\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 10/40: 100%|██████████| 469/469 [00:06<00:00, 67.02it/s, loss=102.57, recon=59.25, kld=14.44]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 10/40:\n",
-            "  Total Loss: 101.3169\n",
-            "  Recon Loss: 56.5741\n",
-            "  KLD Loss:   14.9143\n",
-            "  LR:         0.000854\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 11/40: 100%|██████████| 469/469 [00:07<00:00, 66.32it/s, loss=95.58, recon=52.09, kld=14.49]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 11/40:\n",
-            "  Total Loss: 100.4484\n",
-            "  Recon Loss: 55.7486\n",
-            "  KLD Loss:   14.8999\n",
-            "  LR:         0.000825\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 12/40: 100%|██████████| 469/469 [00:06<00:00, 69.61it/s, loss=106.48, recon=61.20, kld=15.09]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 12/40:\n",
-            "  Total Loss: 99.7889\n",
-            "  Recon Loss: 54.9504\n",
-            "  KLD Loss:   14.9462\n",
-            "  LR:         0.000794\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 13/40: 100%|██████████| 469/469 [00:06<00:00, 70.44it/s, loss=98.21, recon=54.85, kld=14.45]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 13/40:\n",
-            "  Total Loss: 99.0021\n",
-            "  Recon Loss: 54.1854\n",
-            "  KLD Loss:   14.9389\n",
-            "  LR:         0.000761\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 14/40: 100%|██████████| 469/469 [00:06<00:00, 69.77it/s, loss=95.96, recon=52.44, kld=14.50]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 14/40:\n",
-            "  Total Loss: 98.4553\n",
-            "  Recon Loss: 53.6580\n",
-            "  KLD Loss:   14.9324\n",
-            "  LR:         0.000727\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 15/40: 100%|██████████| 469/469 [00:06<00:00, 68.60it/s, loss=100.39, recon=54.58, kld=15.27]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 15/40:\n",
-            "  Total Loss: 97.7684\n",
-            "  Recon Loss: 52.9638\n",
-            "  KLD Loss:   14.9349\n",
-            "  LR:         0.000691\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 16/40: 100%|██████████| 469/469 [00:07<00:00, 66.87it/s, loss=98.62, recon=54.15, kld=14.82]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 16/40:\n",
-            "  Total Loss: 97.1275\n",
-            "  Recon Loss: 52.3211\n",
-            "  KLD Loss:   14.9355\n",
-            "  LR:         0.000655\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 17/40: 100%|██████████| 469/469 [00:06<00:00, 68.02it/s, loss=101.81, recon=56.33, kld=15.16]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 17/40:\n",
-            "  Total Loss: 96.7112\n",
-            "  Recon Loss: 51.7768\n",
-            "  KLD Loss:   14.9782\n",
-            "  LR:         0.000617\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 18/40: 100%|██████████| 469/469 [00:06<00:00, 68.33it/s, loss=95.98, recon=52.03, kld=14.65]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 18/40:\n",
-            "  Total Loss: 96.2307\n",
-            "  Recon Loss: 51.2898\n",
-            "  KLD Loss:   14.9803\n",
-            "  LR:         0.000578\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 19/40: 100%|██████████| 469/469 [00:06<00:00, 67.65it/s, loss=96.31, recon=51.58, kld=14.91]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 19/40:\n",
-            "  Total Loss: 95.7229\n",
-            "  Recon Loss: 50.7185\n",
-            "  KLD Loss:   15.0015\n",
-            "  LR:         0.000539\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 20/40: 100%|██████████| 469/469 [00:06<00:00, 68.59it/s, loss=95.81, recon=49.71, kld=15.36]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 20/40:\n",
-            "  Total Loss: 95.2729\n",
-            "  Recon Loss: 50.2923\n",
-            "  KLD Loss:   14.9936\n",
-            "  LR:         0.000500\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 21/40: 100%|██████████| 469/469 [00:06<00:00, 70.03it/s, loss=96.79, recon=50.91, kld=15.30]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 21/40:\n",
-            "  Total Loss: 94.8571\n",
-            "  Recon Loss: 49.7916\n",
-            "  KLD Loss:   15.0218\n",
-            "  LR:         0.000461\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 22/40: 100%|██████████| 469/469 [00:06<00:00, 69.83it/s, loss=92.85, recon=49.92, kld=14.31]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 22/40:\n",
-            "  Total Loss: 94.3545\n",
-            "  Recon Loss: 49.3219\n",
-            "  KLD Loss:   15.0109\n",
-            "  LR:         0.000422\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 23/40: 100%|██████████| 469/469 [00:06<00:00, 67.65it/s, loss=89.15, recon=46.06, kld=14.36]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 23/40:\n",
-            "  Total Loss: 93.9520\n",
-            "  Recon Loss: 48.9202\n",
-            "  KLD Loss:   15.0106\n",
-            "  LR:         0.000383\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 24/40: 100%|██████████| 469/469 [00:06<00:00, 70.42it/s, loss=97.04, recon=50.59, kld=15.48]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 24/40:\n",
-            "  Total Loss: 93.6698\n",
-            "  Recon Loss: 48.5562\n",
-            "  KLD Loss:   15.0379\n",
-            "  LR:         0.000345\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 25/40: 100%|██████████| 469/469 [00:07<00:00, 66.38it/s, loss=93.63, recon=48.76, kld=14.96]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 25/40:\n",
-            "  Total Loss: 93.2344\n",
-            "  Recon Loss: 48.0729\n",
-            "  KLD Loss:   15.0538\n",
-            "  LR:         0.000309\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 26/40: 100%|██████████| 469/469 [00:06<00:00, 70.99it/s, loss=95.92, recon=50.00, kld=15.31]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 26/40:\n",
-            "  Total Loss: 92.9040\n",
-            "  Recon Loss: 47.7253\n",
-            "  KLD Loss:   15.0596\n",
-            "  LR:         0.000273\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 27/40: 100%|██████████| 469/469 [00:06<00:00, 67.86it/s, loss=94.65, recon=48.76, kld=15.30]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 27/40:\n",
-            "  Total Loss: 92.5177\n",
-            "  Recon Loss: 47.3440\n",
-            "  KLD Loss:   15.0579\n",
-            "  LR:         0.000239\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 28/40: 100%|██████████| 469/469 [00:07<00:00, 66.80it/s, loss=91.64, recon=47.16, kld=14.83]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 28/40:\n",
-            "  Total Loss: 92.2325\n",
-            "  Recon Loss: 46.9383\n",
-            "  KLD Loss:   15.0981\n",
-            "  LR:         0.000206\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 29/40: 100%|██████████| 469/469 [00:06<00:00, 68.74it/s, loss=91.66, recon=46.53, kld=15.04]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 29/40:\n",
-            "  Total Loss: 91.9400\n",
-            "  Recon Loss: 46.6532\n",
-            "  KLD Loss:   15.0956\n",
-            "  LR:         0.000175\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 30/40: 100%|██████████| 469/469 [00:06<00:00, 70.07it/s, loss=90.74, recon=45.59, kld=15.05]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 30/40:\n",
-            "  Total Loss: 91.6200\n",
-            "  Recon Loss: 46.2720\n",
-            "  KLD Loss:   15.1160\n",
-            "  LR:         0.000146\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 31/40: 100%|██████████| 469/469 [00:06<00:00, 67.66it/s, loss=92.41, recon=46.05, kld=15.45]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 31/40:\n",
-            "  Total Loss: 91.4836\n",
-            "  Recon Loss: 46.0025\n",
-            "  KLD Loss:   15.1604\n",
-            "  LR:         0.000120\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 32/40: 100%|██████████| 469/469 [00:07<00:00, 66.39it/s, loss=92.47, recon=45.54, kld=15.65]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 32/40:\n",
-            "  Total Loss: 91.1364\n",
-            "  Recon Loss: 45.7416\n",
-            "  KLD Loss:   15.1316\n",
-            "  LR:         0.000095\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 33/40: 100%|██████████| 469/469 [00:06<00:00, 69.19it/s, loss=92.42, recon=46.17, kld=15.42]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 33/40:\n",
-            "  Total Loss: 90.9708\n",
-            "  Recon Loss: 45.5071\n",
-            "  KLD Loss:   15.1546\n",
-            "  LR:         0.000074\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 34/40: 100%|██████████| 469/469 [00:06<00:00, 69.59it/s, loss=91.69, recon=45.05, kld=15.55]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 34/40:\n",
-            "  Total Loss: 90.7663\n",
-            "  Recon Loss: 45.2975\n",
-            "  KLD Loss:   15.1563\n",
-            "  LR:         0.000054\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 35/40: 100%|██████████| 469/469 [00:07<00:00, 66.66it/s, loss=89.61, recon=45.11, kld=14.83]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 35/40:\n",
-            "  Total Loss: 90.6349\n",
-            "  Recon Loss: 45.1655\n",
-            "  KLD Loss:   15.1565\n",
-            "  LR:         0.000038\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 36/40: 100%|██████████| 469/469 [00:06<00:00, 70.33it/s, loss=91.76, recon=45.89, kld=15.29]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 36/40:\n",
-            "  Total Loss: 90.4321\n",
-            "  Recon Loss: 44.9360\n",
-            "  KLD Loss:   15.1654\n",
-            "  LR:         0.000024\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 37/40: 100%|██████████| 469/469 [00:06<00:00, 68.09it/s, loss=90.18, recon=44.17, kld=15.34]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 37/40:\n",
-            "  Total Loss: 90.3418\n",
-            "  Recon Loss: 44.8862\n",
-            "  KLD Loss:   15.1519\n",
-            "  LR:         0.000014\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 38/40: 100%|██████████| 469/469 [00:06<00:00, 70.10it/s, loss=86.92, recon=42.46, kld=14.82]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 38/40:\n",
-            "  Total Loss: 90.3192\n",
-            "  Recon Loss: 44.7839\n",
-            "  KLD Loss:   15.1784\n",
-            "  LR:         0.000006\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 39/40: 100%|██████████| 469/469 [00:06<00:00, 68.99it/s, loss=88.95, recon=43.57, kld=15.13]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 39/40:\n",
-            "  Total Loss: 90.2579\n",
-            "  Recon Loss: 44.7357\n",
-            "  KLD Loss:   15.1741\n",
-            "  LR:         0.000002\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Epoch 40/40: 100%|██████████| 469/469 [00:06<00:00, 68.30it/s, loss=96.90, recon=50.91, kld=15.33]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 40/40:\n",
-            "  Total Loss: 90.1953\n",
-            "  Recon Loss: 44.6755\n",
-            "  KLD Loss:   15.1733\n",
-            "  LR:         0.000000\n",
-            "\n",
-            "✓ VAE checkpoint saved!\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Visualize Reconstruction"
-      ],
-      "metadata": {
-        "id": "S5V6ZPq_M7Cl"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "print(\"=\"*60)\n",
-        "print(\"Visualizing VAE Reconstruction\")\n",
-        "print(\"=\"*60)\n",
-        "\n",
-        "vae.eval()\n",
-        "with torch.no_grad():\n",
-        "    test_dataset = datasets.MNIST('./data', train=False, download=True, transform=transform)\n",
-        "    test_loader = DataLoader(test_dataset, batch_size=16, shuffle=True)\n",
-        "\n",
-        "    data, _ = next(iter(test_loader))\n",
-        "    data = data.to(device)\n",
-        "\n",
-        "    recon, mu, logvar = vae(data)\n",
-        "\n",
-        "    plot_results(data, nrow=8)\n",
-        "    plot_results(recon, nrow=8)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 573
-        },
-        "id": "cxGf-IkMIi6s",
-        "outputId": "ea84a74d-8854-43ce-fb51-23ca5ccdf136"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "============================================================\n",
-            "Visualizing VAE Reconstruction\n",
-            "============================================================\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 3000x900 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAACVEAAAKICAYAAABzbCh9AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAuIwAALiMBeKU/dgAAThNJREFUeJzt/Hm4HeKh//1nsYVIQkTMSUONpygJR0LR0pAU0Riy6aG0lBNKNCntqRI1dVBJ9DhHzcWXIxI0yKC0qtoMbSXkqHkIkpgiESRBIlnPX9/nun4/+viw1s7a2ffr9ff7WvedyF577bU/VqVarVbbAQAAAAAAAAAAFGqNRl8AAAAAAAAAAACgkYyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAitbUqIMrlUqjjgYAAAAAAAAAAFqharXakHN9EhUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFC0pkZfgNXLGWecEXWjR49u4Zt8vEqlEnXVarWu544YMSLqLr/88qh7++23a7kOALAa6NatW9TtsssudT131qxZUffmm2/W9VwAAABat+bm5qi77bbbom7atGlRd9lll0Xd2LFjow7aknXXXTfq+vTpE3WTJ0+OurXXXjvq7rjjjqg7+uijo+7DDz+MOqA2PXr0iLp+/fpF3SGHHBJ1hx12WNTV2zPPPBN1F1xwQdT9z//8Ty3XoZXzSVQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0SrVarXakIMrlUYcS40OOOCAqLvzzjujbt11163lOqudhx56KOouueSSqJs8eXIt14HPbM0116xrlxo0aFDU7bTTTnU99xvf+EbUbb311nU9t96eeOKJqDvvvPOi7o477qjlOrBKbLTRRlH39a9//RObk046KXqsDh06RF3nzp2j7nOf+1zUpa+vX3rppagbNmxY1I0fPz7qAAAAqK/u3btH3ahRo6Ju8ODBtVynxfXo0SPq5s6d28I3oUQbbLBB1P3Lv/xL1B111FFRd+yxx0bd+uuvH3Wp9H2m9NfMY8aMibr0zwulSd8jvvzyy6Puq1/9atSlv8tv0OSk7lasWBF1Q4YMibrrr7++lusUr1H/rnwSFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFC0SrVarTbk4EqlEceyigwePDjqhg0bFnV9+vSJukceeSTq5s2bF3Xbbrtt1G2//fZRl1q6dGnUHXzwwZ/YPPTQQ7Veh4K0b98+6kaNGhV1p5xySi3XoUFmzZoVdV/5ylei7p133qnhNvDxDjzwwKj7xS9+EXVf/OIXa7lOq5C+vk5f/n/44YdRN3HixKg7/PDDow4AAGB11L1796hrbm7+xObII4+MHmvPPfeMutScOXOi7rLLLou69D3E5O+kXbt27caOHRt1tG1rrrlm1PXu3TvqhgwZEnX9+vWLui222CLqWrt6v8+Uvkd8wAEHRN2MGTOiDtqKn//851F31lln1fXcej8XtBUffPBB1KW/R/vb3/5Ww23arkb9u/JJVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRKtVqtdqQgyuVRhxLK9OlS5eo22mnnaLu6aefjrr58+dHXY8ePaJu6NChUTd8+PCoS02aNOkTm4EDB9b1TNq2n//851F31llntfBNVk/vvvtuXR+vc+fOUbds2bKoW7x4cdSdfvrpUTdmzJiog5YwY8aMqNt1113rdubMmTOjbvLkyVH3xBNP1HKdz+z73/9+1PXu3TvqPvjgg6g79thjo+7OO++MOqB2ffv2jbrPfe5zUde9e/e6npt26c9tqfR5ctSoUXU9F1q7Aw44IOp+/etfR93nP//5qLvrrruibtNNN426efPmRd0LL7wQdbNmzYq6e++9N+oWLFgQdUDt0vdqjzzyyKjbc889a7nO/485c+ZE3fTp06Mufd2SPh60hPQ9nEMPPTTqRowYUcNteOyxx6Ju5513ruu5Rx99dNTdfvvtdT0XWrvjjjsu6q6++uqoW2uttaIu/Z363XffHXWzZ8+OulT6XtSQIUPqem4q/Tn6gQceaOGbrJ4aNGXySVQAAAAAAAAAAEDZjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0ZoafQHKtmjRoqj7y1/+0rIX+SfmzJkTdc8//3wL3+TjbbXVVg05l7ZryZIljb7C/6f0OePll1+OuquvvrqG23zU3XffHXWVSiXqBg4cGHWzZ8+OunvvvTfqYHWw3XbbRd2CBQui7qSTTvrEZuLEidFjffjhh1HXKDNmzIi6SZMmRd3nP//5qLvhhhui7qmnnoq6J554IupgdTB8+PCoO/LII6Nuzz33rOU6xRs5cmTUTZ06NeqmT59ey3WgxW244YZRl35tpK8NUl//+tfr+njLli2Luvbt29f13Oeeey7qBgwYEHUvvPBCLdeBNi19vkpfg6XGjRsXdaNGjfrEprW/fkj/7pI/K/xf6fsV1Wq1hW+yevrv//7vqJs8eXLUpb+XS9+zB2pz0003Rd3cuXOjbuONN466MWPGRF2jDBo0KOqGDBnSshehTfFJVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRmhp9AWjN2rdvH3WHH354C98EVo3nnnuuIecuWLAg6vbcc8+oe/7552u5zme28cYbR12HDh2i7rrrrou6ZcuWRR20Jen33r///e9Rt2jRohpus3rZaKONoq5bt251Pbdjx45Rd+2110Zdv379om7p0qVRB59G3759o27s2LFR16NHj1qu0+LmzJkTdePGjYu6v/71r7Vc5yP69OkTdcOHD4+69M87ffr0qIPWbr/99ou6nXbaqa7nXnjhhVH34IMPRl2lUom6119/PerSn++22267qLvgggui7sc//nHUnXjiiVEHJRo8eHDUpd/z99prr6ibO3du1DVC9+7doy59/Tpt2rRargO0a9duypQpUffLX/4y6n73u99F3fLly6OuU6dOUVdvW2+9dUPOhbbigQceaPQVVqnm5uZGX4E2yCdRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEVravQFaB369esXdfvuu28L36R12XvvvaPuy1/+cl3PffHFF6Pu8ssvr+u5sMsuuzTk3HXWWSfqRowY0cI3qU36XLrppptG3b333ht1b775ZtRdddVVUff8889H3euvvx510BLuv//+Rl9htTV16tSo22CDDaJu/PjxUTdw4MCo69OnT9R9/etfj7pbb7016uDT+NznPlfXxxs1alTUjRs3Lurmzp1b1661O/LII+v6eNOnT6/r40GjrLXWWlH3b//2b3U996GHHoq6Cy64IOpWrFhRy3U+s8cffzzq/vznP0fdaaedFnXbbrtt1AG1awuvmZqbm6Pu0ksvjbr0zzp69Oiog0/j+uuvj7pvf/vbdT130aJFUZe+F3XLLbdE3e9///uoe//996Ou3k488cSGnPvuu+825Fxg1WhqyuYp55xzTtQNGjSohtt8dvPnz4+62bNnt/BNaAk+iQoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAoWlOjL0DLOuigg6Ju/PjxUbfmmmvWcBuee+65qBswYEDUzZ49u5brwEe8+eabDTm3Y8eOUXfssce28E1al/S5IJX+/b300ktRd/XVV0fdpZdeGnUffvhh1AGty4QJE6Ju4MCBdT33C1/4Ql0fDz6NsWPH1rXj4/Xt2zfqBg8eXNdz58yZU9fHg0bp1atX1A0aNCjq5s6dG3XHHHNM1K1YsSLqWrsDDjgg6nbccceoO/fcc2u5DtCuXbtx48ZF3fDhw6Nu5MiRUff9738/6hL1vtu0adOirrm5OerS7wnwafzwhz+Muoceeijqpk6dGnUffPBB1JX2775fv34NOfeNN95oyLlAbfbee++ou/jii+v6ePW2bNmyqDv11FOjzu/yV08+iQoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAoWlOjL8Bn06lTp6gbNmxY1K255pq1XIfQrFmzom727NktfBP4eKNHj466bbfdNuq+853v1HKd1c7ixYuj7tlnn4267bffPurWXXfdqEv17Nkz6i6++OKo69ChQ9RdcMEFUbdixYqoA1aNu+++O+quuuqqFr4J0NYMHjy4Ieemr4mhtUu/hpYuXRp1p59+etTNmzcv6tqKHXfcsdFXAP7/jBs3LurS58m0S19DJO/ZDx8+PHqsOXPmRF1zc3PUzZ07N+qgJSxcuDDq/s//+T8tfJO2bffdd4+6gw46KOqq1WrULVq0KOrS986BVeO73/1u1J133nlRt+GGG9ZynRa3fPnyqLvzzjtb+CY0kk+iAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIrW1OgL8Nl07tw56rbbbrsWvgmfxiabbBJ16623XtS98847tVwHPmLFihVRd9ppp0XdXXfdFXXrr79+1H3uc5+Lusceeyzq6m3BggVR99e//jXq9txzz6jbYIMNom7HHXeMup/85CdRt84660TdOeecE3Xjxo2Lun/84x9RB7QulUqlVT8esOr07ds36oYPH17Xc9PXGnPnzq3rudAo+++/f9Q99dRTUZf+fFea/v371/XxJk+eXNfHgxJNnz496i677LKoGzlyZNRNnTo16nr06PGJzbRp06LHam5ujjqvb4D/q1OnTg05980334y6WbNmtfBNgHbt2rXbddddo+7iiy+OunS70Nqtu+66UffTn/406s4+++xarkOD+CQqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhNjb4An82rr74adYceemjUTZ48Oeo22WSTqKu39957L+qefvrpqJs4cWLUHXzwwVH3xS9+Mer23nvvqLvyyiujbsiQIZ/YvPPOO9FjwaexfPnyqJs0aVIL36RtmzZtWl0fL/3v8e6770bdqFGjom7ttdeOunPPPTfqvvGNb0TdypUrow7qbYcddoi6LbbYIupefvnlqHv22Wejrt569OgRddVqta7n3n333XV9PGDVGT58eF0fb86cOQ05F1q7c845J+o233zzFr7J6ql///5Rt88++0TdlClTom7WrFlRB9Ru7ty5dX289Gej5P2e5ubm6LHq/WcAVl977rln1I0YMSLq1lgj+xyO9D3Y9HcKwKrx6KOPRl2lUqlrl0rf60lff6XSP8chhxwSdWeffXYt16FBfBIVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAULSmRl+AljVr1qyo69+/f9TttNNOtVznM3vrrbei7t57763ruSNGjIi6l19+Oeq22GKLqDvqqKOi7pZbbvnEZuLEidFjAfxfV155ZdQ1NzdH3Ze//OWoO/LII6PuhBNOiLolS5ZEHaun3XffPeoGDBgQdem/50T6/b5Lly5Rt3Dhwqi77bbbom7SpElR9/zzz0fd+eefH3WpF154IeqeeOKJup4L1C59Lh08eHBdzz3zzDOjbu7cuXU9F1q7yZMnN/oKq7UvfelLUde+ffuo++Mf/xh1K1asiDqgdn369GnIuZdddtknNl63AJ/WV77ylajbd999o27lypVRl752ueiii6IOaF3S99dPOumkqPvtb38bdQ8//HDUNeo1U7Vabci5rBo+iQoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAoWqVarVYbcnCl0ohjoUUMGTIk6v77v/+7ruceeuihn9hMnDixrmfC6qBXr15Rt+6660bdlClTarlOm/Wd73wn6q666qq6nrveeutF3ZIlS+p6LrVZf/31o27UqFFRd+yxx9ZynY9YuHBhXR+vnrp16xZ1a665ZtStWLEi6j788MOoa9++fdSlrr/++qg76aST6nou8M9179496qZOnRp1PXr0iLpp06ZF3V577RV1AO3atWt34IEHRt2kSZOi7r333ou6XXfdNeqef/75qAP+ueHDh0fdyJEjo27OnDlRl77GGTdu3Cc2zc3N0WMBbV/nzp2j7tlnn4269H2m9Pe4b7zxRtTts88+UZd65ZVXom7p0qV1PRdYNfbff/+ou//++1v4Jh/vH//4R9TtsssuLXyTtq1BUyafRAUAAAAAAAAAAJTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUranRF4C2YP/992/0FWC11qFDh6j79a9/HXUDBw6MurXXXjvq+vfvH3VTpkyJurZi++23b/QVaAV23nnnqJs0aVLUbb755lH3zDPPRN3QoUOj7v7774+6Rkif0w477LCoO/7446Ouffv2UVdvEyZMaMi5wD/X3NwcdT169KjrucOHD6/r4wFt21prrRV16evDNdbI/t/TK6+8Muqef/75qAP+ub59+0bdyJEjo27atGlRd9lll0XdbbfdFnUA7drl763+6le/irpu3brVcp3PbKONNoq6p556qq7n3nrrrVGXfk9ILViwIOrmzJlT13OhNHfccUdDzq1Wq1E3atSoFr4JjeSTqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiNTX6AqX4yU9+EnXDhg2LutmzZ0fdrrvuGnXUpn///o2+AqzWzj333Kj75je/Wddzb7/99qibNWtWXc9t7bbccsuoO/7441v2IqwW7rvvvqjbeOONo+6Xv/xl1P3qV7+KuldffTXqWrN77rkn6g4//PAWvsmqcc0110Tdl7/85agbPnx4LdeBNq1v375RN3LkyLqeO2rUqKibPn16Xc8F2rbm5uaoO+igg+p67ksvvVTXx4MSde/ePerq/do+fby5c+fW9VygdenYsWPU9erVK+q22WabqBs9enTUde7cOepK841vfKOuXWrevHlRd8MNN0Td+eefH3UrV66MOlY/m2++edT16NGjhW+yahx77LFRlz4319vSpUuj7sYbb2zhm9BIPokKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKFpToy+wujvyyCOj7j/+4z+ibq211oq6jTfeOOq22mqrqJs9e3bUtRW9e/eOurFjx0Zdx44da7nOR1x33XVR98ADD9T1XGiUjTbaqCHnbrDBBlG3ePHiFr5J63LrrbdG3YYbbljXc2+44YaoW7p0aV3PpTabbLJJ1FWr1agbM2ZM1L366qtRV0/p67T27dtH3RFHHBF155xzTtRts802UZf+t3j44Yej7pe//GXUDRgwIOqOP/74qBs6dGjU9e/fP+puueWWqPvwww+j7pJLLok6aAndu3ePuvTnndScOXOibvTo0XU9F6Bdu3bt9t5777o+3rx586Lupptuquu5UKLm5uaoGzx4cNSNGzcu6qZPnx516f1S6Ws1oDZbbLFF1N11111Rt+uuu9ZwG9qK9N/Vj3/846i7/fbbo+6xxx6LOj7q85//fNT16dMn6tL3OLfbbruo23zzzaOuUa8fKpVK1KXvObd2F154YaOvQCvgk6gAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAojU1+gKruwcffDDqXnnllajr2bNn1G2yySZRN2HChKj72te+FnUvv/xy1DXKDjvsEHU/+tGPom6rrbaq5Tof8eabb0bdqFGjou69996r5TrQajz66KMNOXefffaJuv322y/q/vjHP9ZynRZ3xBFHRN2WW27Zshf5Jy688MKoq1arLXwTPo3bbrst6pqbm6Pu1ltvjbq//OUvUVdPu+yyS9TttttuLXyTj1epVKLu8ssvj7rzzjsv6hYtWhR1t99+e9Q9/fTTUTds2LCoS18f/uAHP4i69N8yNFL677RHjx51PffMM8+Murlz59b1XKBt23bbbaNu8ODBdT13/PjxUffOO+/U9VxoS/r27Rt1I0eOjLpp06ZFXb1fs3fv3r2uj+e1EKwa3/3ud6Nu1113bdmLtDJPPfVU1B1zzDEtfJNVY+utt466er+WHDhwYNSl37Mee+yxWq7TZm2zzTaf2Nx3333RY6W/o2f1NHbs2Ki79NJLW/gmrA58EhUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQtEq1Wq025OBKpRHHNsxZZ50VdT//+c9b+CYf75lnnom6G2+8MeruuuuuqNtuu+2i7jvf+U7U7brrrlG3+eabR129/frXv4660047rYVvAq1L165do27KlClRlz63pP7xj39E3XnnnRd148ePj7ojjjgi6vbdd9+oGzJkSNQ1NTVFXeqGG26IuvS5vkEvXfgn1llnnajba6+9WvgmpGbNmhV1CxYsaOGb1KZnz55Rt/XWW0fd/Pnzo+6xxx6LOmgJffv2jbpp06bV9dxRo0ZF3fe///26ngvQrl27dt/61rei7vrrr4+6FStWRN0hhxwSdb/73e+iDkrU3NwcdbfddlvUjRs3rq7nNuq1VY8ePT6xmTt3bl3PhBL967/+a9TV+2u8UZ544omoO+CAA6Lu9ddfr+U6xUvft3r33XejbuHChbVcp81Kfh+dvq7n462xRvaZPCtXrmzhm3y8v//971E3cODAqEvfI2bVaNTvA30SFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFC0SrVarTbk4EqlEcc2TPfu3aPuhBNOiLrTTz896rp27Rp11ObUU0+NultuuSXqFi9eXMt1oM367ne/G3X/+Z//2cI3+Xgffvhh1L377rtR17lz56hramqKunq7+eabo+6UU06JuqVLl9ZyHQBo88aOHRt1gwcPjro5c+ZE3V577RV1c+fOjTqAT+ORRx6Jul122SXqpkyZEnX77LNP1AH/XHNzc9TddtttUZe+dkn16NGjrueeeeaZUZe+pgNqs80220TdU0891cI3qc1NN90UdWeffXbUvfbaa7VcB1qVc8455xOb9Ptz+vuY0qSbjvnz50fdtGnTou6KK66IukcffTTq3njjjaijdWnQlMknUQEAAAAAAAAAAGUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFq1Sr1WpDDq5UGnFsm7H++utH3UknnRR1Bx54YNR99atfjbrW7q677oq6qVOnRt2vfvWrqFu+fHnUAR8v/d7Rs2fPqLv33nujbtttt426tmLo0KFRd80110TdsmXLarkOALR5ffv2jbpp06bV9dyjjjoq6saOHVvXcwHatWvXbocddoi6//3f/426tdZaK+quvfbaqEvfUwNql77WSF8z9ejRI+rGjRsXdaNGjYq66dOnRx2waqTvJafPBYMGDYq6559/PuouvPDCqLvllluirkG/7oVWr3///lF32GGHRV1pPydcdNFFUXfFFVdE3euvv17LdShMo763+SQqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGiVarVabcjBlUojjgWA/9cWW2wRdSeffHLUHXPMMVG31VZbRd1zzz0Xdeeff37UjR07Nuo+/PDDqAMA6mPkyJFRN3z48KgbN25c1DU3N0cdQEs4+OCDo+6ee+6p67lDhw6Nuv/6r/+q67kAAABArkFTJp9EBQAAAAAAAAAAlM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABStqdEXAIBGmTdvXtSdd955de0AgDL07ds36oYPH17Xc+fMmVPXxwNYHSxfvjzqxo8f37IXAQAAAFZbPokKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKFpToy8AAAAAbdH06dOjbty4cVE3ePDgqOvRo0fUATTSq6++GnVz5syJuilTpkTd3Llzow4AAAAoj0+iAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpWqVar1YYcXKk04lgAAAAAAAAAAKCVatCUySdRAQAAAAAAAAAAZTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoTY2+AADUW1NT9u3tJz/5SdTNmzcv6m644Yaoe++996IOAAAAAAAAgFXDJ1EBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARatUq9VqQw6uVBpxLAAFGDJkSNRdccUVdT33hRdeiLoxY8ZE3SWXXBJ177zzTtQBAAAAAABQtrXWWivqzjjjjKg755xzou6hhx6KuqOPPjrqli5dGnWsnho0ZfJJVAAAAAAAAAAAQNmMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRKtVqtdqQgyuVRhwLQAGGDh0adZdddlnLXqRGU6ZMibrhw4dH3d///vdargMAAAAAQB106tQp6iZMmBB1M2bMiLpbb7016h555JGoW7FiRdQBq8Yaa2SfoXPCCSdE3VVXXVXLdT4i3Yh8/etfj7p77rmnluvQyjVoyuSTqAAAAAAAAAAAgLIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiVarVarUhB1cqjTgWgAK0b98+6oYOHRp13/3ud6OuZ8+eUVdv8+bNi7qdd9456hYtWlTDbYBG2XbbbaPutNNOi7ouXbpE3fvvvx91J510UtRNmzYt6r70pS9FHQAAQGvS1NT0ic2ZZ54ZPdY999wTdY8//njUpW666aaoS3/99OKLL0bdtddeG3Vz5syJOmik3//+91GXvv/x7rvvRl3Xrl2jbtKkSVF36KGHRh2wauyxxx5Rl74Hm0pfa1xyySVRd9ddd0Vd+tzH6qlBUyafRAUAAAAAAAAAAJTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUrVKtVqsNObhSacSxAPCprbvuulHXtWvXqLv66qujbsCAAVGXuvnmm6Pu9NNPj7q33367lusAoQsuuCDqhg0bFnXpc1oqfV2f/tjx+uuvR93mm28edQAAAKtCz549o+6GG274xGafffaJHuvaa6+NuiFDhkRdasWKFVFX718//eEPf4i6gQMHRt2yZctquQ58rO7du0fdzJkzo65z585Rd+edd0bdAQccEHXpe93f/OY3o+7WW2+NOuDj9e3bN+omT54cdeutt14t1/mI7bffPuqee+65up5L29agKZNPogIAAAAAAAAAAMpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACK1tToC7B6WWONbHd35JFHRt3WW28ddaeffnrUbbrpplGXevDBB6PusMMOi7q33367htsAjbJ06dK6dgcddFDU/exnP4u6H/7wh1F37LHHRt19990XdTfffHPUAR8v/do955xzoq5arUbdggULoq6pKftRoUuXLlEHQH107tw56i6++OKo++CDD6LurLPOijpIdejQIerS10zp10bv3r2j7rbbbou6a665JupWrFgRdT179oy6oUOHRl3qrrvuirqHHnqorufC6uCQQw6JulGjRkVd8p54+vPdn/70p6irt6uuuirqXnrppag77bTTou6rX/1q1K2//vpRN3/+/KiDT+PUU0+Nuq5du0ZdpVKJuvT3VPWWvtd96623tvBNoG0bPXp01K233np1PffJJ5+MuiVLltT1XGgkn0QFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFK1SrVarDTm4UmnEsfwTe+21V9RdcMEFUbf//vvXcp2PSP+9NOifc7vx48dH3eGHH96yFwHalA033DDqnnzyyajr1q1b1E2YMCHqDj300KiD0vTu3Tvq7r333qhLv3bvv//+qDviiCOirlOnTlH3yiuvRF36Ou2WW26JuuOOOy7qgH9u++23j7rZs2dH3bJly2q5TvHS/x6/+tWvoq5fv35Rt8cee0TdzJkzow623XbbqLvhhhuirk+fPlHXqPeOLrrooqj76U9/GnWXXXZZ1J188slRlzrrrLOibvTo0XU9FxqpZ8+eUTdlypSo23TTTaMueb56/PHHo8fabbfdom758uVR1yjpz8fp65vNNtss6ubPnx910K5du3YHHnhg1E2ePDnqJk6cGHWXXnpp1KXPB6lhw4ZFXZcuXaJu7733jrr//d//jTpoK9L3an/zm99EXceOHaPuhRdeiLr0ve5333036uDTaNT2wydRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEVravQFaFlrr7121N18881Rt+WWW0bdvHnzou6GG26Iuvfffz/qJkyYEHU77LBD1PXv3z/qunTpEnUAn8aCBQuiLn2OTH3ta1+Lug022CDq3nrrrVquA6ud66+/Puq6desWdQsXLoy6o446KuoWL14cdbvsskvUVSqVqHv33Xej7sYbb4w64J/bfffdo+7++++PulNOOSXq7rjjjqhbvnx51LV23bt3j7pf/vKXUTdgwICo69y5c9TdfffdUTdr1qyogw4dOkTdz372s6jr06dPLdf5iHHjxkXdhhtuGHX77bdf1J1zzjlRt/nmm0fdCSecEHX19uyzzzbkXPg00p950u+pxx13XC3X+cyS56ujjz56Fdyk9Xj44YejbuzYsVE3f/78Wq4DH+vEE0+MumnTpkVdc3Nz1KXv/T700ENRV2+XXnpp1A0bNizqvv3tb9dyHVjtpK9vOnbsGHVLly6NuvRrLX1PF9oSn0QFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFK2p0RegZZ144olRt+WWW0bdzTffHHVnnXVW1L3++utRV2/PPfdc1G222WZR9+KLL9ZwG4DWZc0112z0FaBVSl8XbLrpplFXrVaj7kc/+lHULVq0KOpSu+22W9Slf47nn38+6v7whz9EHZTokksuiboBAwZEXefOnaMu/TpvK9K/v/T5eeedd4669L/HMcccE3V/+9vfom7FihVRBz/84Q+jbtCgQXU999RTT426q6++Oup69uwZdVOmTIm69LVf+h5dvZ9z07+/CRMm1PVc+DQuv/zyqEv/PadfR416jbP11lt/YrPXXntFjzV16tRar/OZrLfeelGX/rf96le/GnUzZsyIuo4dO0Zdej/ato033jjq9ttvv6i78soro+7999+Puka59dZbo+7f//3fo65v375R17Vr16hbuHBh1EGjpM8tRxxxRF3Pveyyy6LuL3/5S13PhbbEJ1EBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARWtq9AVoWQcccEBdH2/kyJFR9/rrr9f13Hr73ve+F3UXXnhh1J199tk13AYAWB1stNFGde1S77//fl0fr2vXrlF3yimn1PXcmTNn1vXxoC0ZNGhQ1J100klRt2TJkqi76KKLou63v/1t1C1fvjzq6m2dddaJuuOOOy7qfvazn0Xd+uuvH3Wpyy+/POrS/x7Lli2r5ToUZN999426Qw45JOoqlUrUTZkyJer+53/+J+pSL730UtSNGDEi6q655pqoW2ON7P9lXblyZdQ16u8PWsIRRxzR6CusUsnzwQsvvLAKbvLZdejQIeqOOeaYup578MEHR92TTz5Z13Np20499dSoe/HFF6Mu/b1Sa/faa69F3cSJE6PujDPOiLqjjz466q644oqoA4BPyydRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEVravQFaB3ee++9qHv77bdb+Ca12WijjaLu5JNPruu5ffr0qevjAXwalUqlro83ceLEqHvrrbfqei60dum/+bTbYIMNarnOZ3bCCSdE3XbbbRd1r7zyStQNHz486mB10K1bt6ibMmVK1G266aZR17Fjx6j75je/GXUTJkyIukbp27dv1N18881Rt+WWW9Zwm496/fXXo+6YY46JuqlTp0bdsmXLog5SI0aMiLpevXpF3bvvvht1Q4YMibrFixdHXapTp05Rd8YZZ0RdtVqNupUrV0bdgw8+GHWDBw+Ounr//UFbct1110Xd5ZdfXtdzX3vttU9s3nzzzbqeWW+nnHJKQ85NX7/++Mc/buGb0JYccsghUXffffdF3fLly2u5zmrnoYceirrvfe97UTd06NCou+WWW6Kutf9eE4DWxydRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEVravQFaFlLly6Nug4dOkTdMcccE3U333xz1KW22WabqBs3blzUdenSpYbbfFS1Wq3r40Frt9VWW0XdLrvsEnX/+Z//Wct1PrOXXnop6v70pz9F3WOPPRZ1M2fOjLrddtst6jbddNOoS6X3g9LMmTMn6ubOnRt1Xbt2jbrNN9886vbYY4+o+9GPfhR1lUol6i644IKoe+edd6IOVgfDhw+Puq233rqu544ePTrqfve739X13Ea57777om7dddet67nz58+PukMPPTTqZsyYUct1oMVtu+22dX28f/zjH1H3xBNP1PXc9L2tG264Iep23HHHGm7zUVOmTIm6wYMHR93ChQtruQ6sEj//+c+jrlu3bnU998Ybb4y60047LeqWL19ey3XapIcffrgh5y5atCjqVqxY0bIXoU3p1atX1LWVn7PqLf257c4774y6ww47LOrS17CNer6CVPoebKMer97S3xuOGDEi6tLnjNRrr70Wdf3794+69PeGtC4+iQoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAoWlOjL0DLGj16dNQNHDgw6i688MK6dkDrcswxx0TdddddF3Xt27ev5Totrnv37lH3pS99qYVv0rqkf94uXbpE3ZIlS6Ju+fLlUQet3VtvvRV11Wo16s4///yo+7d/+7eoS792r7rqqqi7+uqrow5WBz/5yU+ibtiwYXU99/jjj4+6O+64I+oa9T119913j7p777036jp27Bh16fNp+vx80UUXRV1rf60LqZkzZ0Zd+vPTZpttFnWHHHJIXR9viy22iLpBgwZFXb399re/jbqFCxe28E2gdocddljUnXXWWXU9d9y4cVF34okn1vXckqy77rpRd88990TdypUro27ZsmVR98ADD0QdtGvXrt03vvGNuj7eI488UtfHayvee++9qBs5cmTUpd9jxo8fH3X77bdf1D377LNRB/WWvqdR78dL33Pp27dv1H3rW9+KuvT3kOmfo95/f5tssknU/cd//EfUpX9eWhefRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUrVKtVqsNObhSacSx/BPHHXdc1J122mlRt/vuu9dync9s6tSpUff0009H3be//e2oGz9+fNQdfvjhUQeNMnv27Kjr2bNnC9+EtuSZZ56JulmzZrXwTT7eb37zm6i79957W/gmtBXbb7991D3xxBNRl75uTl/W//nPf466Qw45JOoWL14cdbA6+OMf/xh1++67b9S99dZbUde/f/+oS3+OqbcvfvGLUZd+r+zYsWPUrbFG9v99rVixIuoee+yxqOvVq1fUQWneeeedqEu/xuut3q+ZUn/605+ibv/996/rudASevfuHXV333131G266aZRN3/+/KhLv46efPLJqCtJly5dou6uu+6Kur333jvq3nvvvagbOnRo1F1//fVRB+3atWvXqVOnqHv77bej7qijjoq622+/PepK0759+6ibMmVK1KU/t5111llRN3r06KiD1MYbbxx1r776al3PffPNN6Mufe7beuuta7nOR6Q/t82bNy/qJk+eHHXHH3981DU1NUVdvf/+0vcQS9OgKZNPogIAAAAAAAAAAMpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACK1tToC9A63HTTTVF38803R13nzp1ruc5ntnjx4qg799xzW/gmsHrq2bNnQ8595513ou6FF16Iug8++CDqpk+fHnXHHHNM1HXr1i3qSrPddtvVtau3Qw89NOo6dOjQwjehrZg9e3bUzZw5M+p22223Wq7zEX/961+jLn1dBW3JrFmzom6fffaJui5dukRd+nXZVqTPLxMmTIi6P/zhD1F3/fXXRx3w8b72ta9F3S9+8Yuo22mnnaKuU6dOUZeqVqt1fbwLL7ywro8HjXTGGWdE3aabbhp1r776atQdcsghUffkk09GXUl69+4ddZdccknUfelLX6rlOh/xs5/9LOq8TqMlnHzyyVG3xho+b2JVWLZsWdSdf/75UXfnnXdGXaVSiTqotzfeeCPqbr/99qg78sgjoy79PVW9f5+1YMGCqBs0aFDUzZgxI+rS3wem7zGNGTMm6tZff/2oa2oyx1kdeWUAAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFK2p0Rdg9bJy5cqoe/vtt1v4Jq1LpVJp9BVgtfaDH/wg6q6++uqoW2eddaLuC1/4QtTtscceUdetW7eoa5T0uTn9+1t77bVruQ60Wf369Yu63Xbbra7npq9H9t9//6jr2rVr1C1cuDDqYHXw1FNPNfoKq7XZs2dH3RVXXBF1o0ePruU6QJ1NmTIl6vbee++o23HHHaPukksuiboBAwZEXWru3LlRN2vWrLqeCy1hn332ibqDDz64ruf+13/9V9SV9nWUvO9y6qmnRo81YsSIqOvUqVPUpU466aSou/POO+t6Lnwa1Wo16tLfe7FqTJ06NeoWLFgQdem/A2iUefPmNfoK/58uvvjiqPvFL34RdUuWLKnlOp/ZpEmTou7Pf/5z1PXq1Svqli9fHnW0Lj6JCgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAAChaU6MvAG3BzJkzG30FqIuXXnop6nr27FnXc08++eSoGzhwYNRttdVWUfeFL3wh6hqlUqlE3QUXXBB1o0ePjrr072/zzTePuq233jrq0n9X77//ftS99957UXf33XdHHayzzjpRN2rUqKirVqtRN2fOnKjbbLPNoq53795R99Of/jTqhgwZEnWwOrjmmmui7s0332zhm3y8b3/721HXv3//up67cOHCqOvTp09dHw9o2x5//PGo22mnnVr4Jh/viiuuiDrPaawOJk2aFHUdOnSIuvT9oxtvvDHqWrv0/aMRI0ZE3X777feJzYYbbhg9VuqJJ56IugsvvDDqxo0bV8t1AP6p7bbbLuo6derUwjeBVePcc8+NugMOOCDq6v17r169etX18RrlW9/6VtT169cv6saMGRN1ixYtijpaF59EBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABStqdEXgEZYb7316vp4vXr1quvjQaMcddRRUfenP/0p6tZee+2o6927d9SV5s4774y6Sy65JOqWLFkSdY888khdO2grDjvssKjbdttto27GjBlRd+CBB0bd7bffHnX77bdf1HlupkQrVqyIuvTrLdWxY8eoGzRoUF3PTb+XDxs2LOoWLlxYy3WAwuyyyy5R16VLl6irVCpRN3369KhLf86C1UGnTp2ibuXKlVH30ksvRV21Wo26TTbZJOq+8pWvRN2AAQOi7rjjjou6eltjjU/+f9vT/xaPPvpo1J177rlRN2nSpKgDaCnp+2Dt27dv4ZvAqpH+3ub++++Pun/5l3+JuvTnp4MOOijqxo8fH3UPPvhg1KWvI3fccceoO/roo6MutXz58ro+Hq2LT6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAitbU6AtAI+y88851fbzHHnusro8HjfK3v/0t6i699NKoO/PMM6Nu7bXXjrpG+eCDD6LuxRdfjLpLLrkk6n7zm99EHbBq9OrVq66P9+Mf/zjqFi1aFHUzZ86Muv322y/qdtttt6jr169f1P3+97+POijReuutF3V77LFH1M2fPz/qmpubo2727NlRB/BpfPnLX466jh07Rl21Wo26CRMmRB20JStXroy69Oto3333jbp58+ZFXapSqURd+udIu1T6Guz555//xObKK6+MHiv9Oeu1116LOmhLFi9eHHVrrJF93sSwYcOi7vbbb4+6tmLNNdeMunPPPbeu3cSJE6Nu9OjRUQet3fDhw6Nuk002ibqjjz66lut8xP777x916XvJ6evXervmmmuiLn2uYvXkk6gAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAojU1+gLQCEuXLq3r473wwgt1fTxo7c4999yo++1vfxt1hx56aNT17Nkz6lIvvfRS1N19991RN3PmzFquA7Ry3/zmN6OuUqlE3WabbVbLdT7zuWmXqvefA6jdW2+9FXVLlixp4ZsAJdppp52i7oILLqjruW+88UbUXXXVVXU9F1YHAwYMqGuX/mzUtWvXqEstW7Ys6h588MG6nnvTTTdF3d///veoe+6552q5DhC65pprom7gwIFR17dv36jbd999o+6hhx6Kukbp3bt31KXv7X/ve9+ra5f+94XSnH322VE3fvz4qPv+978fdf/6r/8addVqNepSL7/8ctT9+7//e9Q9+uijUTd//vyoY/Xkk6gAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAolWq1Wq1IQdXKo04ljZuo402irpnn3026tZbb72o69evX9Q98MADUQcAtD7nn39+1J1zzjlR9/7770fdFVdcEXX77rtv1O2+++5R99Zbb0Vd9+7doy7980KJ2rdvH3U9evSIuiVLlkTda6+9FnUAn8Z1110Xdccff3xdz01fq1144YV1PRdKtOWWW0Zdp06d6nruihUrou7JJ5+s67lA27bjjjtG3cSJE6Nu3XXXjbr091Tp71NnzJgRdb179466Xr16Rd3DDz8cdUOGDIm6J554IuqAVaNDhw5RN2bMmKhbf/31o+6RRx6Jul//+tdR98wzz0QdrUuDpkw+iQoAAAAAAAAAACibERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAoWqVarVYbcnCl0ohjaeN69uwZdbNnz67ruRtssEHUvf3223U9FwBYdTbbbLOomzZtWtT16NEj6tLXzenL+pUrV0bdD37wg6gbPXp01AEAq7cddtgh6h5//PEWvsnHGzJkSNRdc801LXwTAKAt2nHHHaPupz/9adQdfPDBUZe+L/TKK69E3ZgxY6Lu2muvjbp58+ZF3eLFi6MOAP6vBk2ZfBIVAAAAAAAAAABQNiMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAULRKtVqtNuTgSqURx9LG9ezZM+pmz54ddQ8//HDU9e3bN+pWrlwZdQDA6mv77bePumuuuSbq9t5776hbuHBh1F188cVRN3r06KgDAMowcuTIqDvjjDNa+CYfr6mpqSHnAgAAAPXXoCmTT6ICAAAAAAAAAADKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAitbU6AtAa7Z48eKoW7lyZQvfBABYXTz99NNRt++++7bwTQAA6mfWrFlRN3fu3Kjr3r171I0ZMybqAAAAAGrlk6gAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAojU1+gLQmr366quNvgIAAABAw910001RN2PGjKi7/PLLo+6HP/xh1AEAAADUyidRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEWrVKvVakMOrlQacSwAAAAAAAAAANBKNWjK5JOoAAAAAAAAAACAshlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACK1tSog6vVaqOOBgAAAAAAAAAA+H/5JCoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACK9v8AW/mbULCm+TsAAAAASUVORK5CYII=\n"
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 3000x900 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAACVEAAAKICAYAAABzbCh9AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAuIwAALiMBeKU/dgAAadBJREFUeJzs3He4nWWd7/+9dk2yk+z0AgkhhZAQCE0CoUgvCqJIszKiHHHmqGdsYxvrGY8zjmMZB7gQVGREQEbpCBgkAgKhBUioIQVI73X3tdfv7/kdz5VPZMHeyfN6/f2+1l57ZT33up97fbNLlUqlUgMAAAAAAAAAAFBQtb39BAAAAAAAAAAAAHqTISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAotPre+sGlUqm3fjQAAAAAAAAAANAHVSqVXvm5/hIVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaPW9/QR2plQqRV2lUnmTnwmwO7BmAAAAAFANzpmAXWHNAPY01jVgV9TWZn/Dqaen501+Jm+Mv0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUWqlSqVR65QeXSr3xYwEAAAAAAAAAgD6ql0aZ/CUqAAAAAAAAAACg2AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLT63n4C7F7q6uqirr4+e2uVSqWoK5fLUZfq6emJukqlUtXHAwAAAAAAgGpKv29Lu1T6PVraAW+NdC2orc3+Jk86Q5B26c/t7u6OunTWIO2saXs2f4kKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAotPrefgK8uRoaGqJu+vTpUXfRRRdF3dvf/vaoGz16dNQ1NzdHXW1tNhfY0dERda+++mrU3XrrrVF38803R92SJUuirrOzM+qgt5RKpap26TVeV1dX1cerr88+LtPfo7GxsaqPl64F7e3tVX28SqUSdbCnqPaa0b9//6hL14z0mkz3QW1tbVFXLpejzpoBAACQ3Vv269cveqyhQ4dG3bBhw6IuvU/duHFj1G3YsCHqtm/fHnXd3d1R5/6T3pSeTQ8aNCjq9ttvv6g79NBDo27y5MlR19LSEnWLFy+OunvuuSfqXnzxxajz/Rh7ivR7oPS78mnTpkXd2WefHXVHHXVU1E2ZMiXq0rUvXUtbW1ujbsWKFVF3yy23RN21114bdatXr4669Iydt4a/RAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRafW8/Af46tbXZ/Nu4ceOi7uKLL466s88+O+pGjhwZdY2NjVGX/r6lUinqBg4cGHVDhw6NugMOOCDqzjjjjKj7+te/HnWPPPLITpvOzs7osaCmJr/Wmpqaoi5dC2bOnBl16bU2derUqJswYULUDRkyJOoGDRoUdQ0NDVHX1tYWdc8++2zUXXPNNVE3b968qNu6dWvUVSqVqIM3Q11dXdS1tLTstJk2bVr0WKeffnrUHX/88VE3fPjwqOvu7o66FStWRN3NN98cdXfccUfUrV+/PurK5XLUAQAAvBXS+8rBgwdH3QknnLDT5vzzz48eKz0ra25ujrpt27ZFXXIuXVNTU3PDDTdEXXq2lT4/Z1Hsivr67KvS9PuiWbNmRd0HPvCBqj7eiBEjoi49m06/b9u+fXvUTZkyJeq++93vRt1rr70WdT09PVEH1ZZeQ6NGjYq6Sy65JOrOOeecqJs8eXLUDRgwIOrS/VL6uqTS/Vf6feW+++4bdelnx09+8pOo27x5c9Tx1vCXqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEKr7+0nwF+ntjabf2tsbIy69vb2qFu/fn3UdXV1RV1bW1vUdXR0RF2pVIq6AQMGRN3QoUOr2h1++OFR953vfCfqLr300p02L7zwQvRYPT09UcfuqaGhIepGjBgRdSeffHLUXXDBBVF38MEHR11LS0vUpWtfupZWW7pWdXZ2Rl26pj3zzDNV7bZt2xZ1lUol6mBXpNf5/vvvH3Uf//jHd9qccsop0WONHj066qq9BpXL5ajbd999o+6II46IuhNPPDHqvvKVr0TdihUroi79feHNkH6W19XVVbVLf266t+/u7o669LO8r3/mp69ffX12VJJ26etc7X8PqLZ075KuaU1NTVGX3s8OHDgw6lJbt26NuvRsK73Gnc/AWyddX6ZMmRJ1X/3qV6Pu6KOP3mmT7jPWrVsXdUuXLo26dL+UruHp2pz+3LRjz5ZeH+n3Nscdd1zUpWfd6eMNGzYs6qp9v1jt+7v0zP7UU0+Nuttvvz3qli9fHnX2VvSW9Pz6yCOPjLpzzz036vbbb7+oSz/L0/vA9FpL15b07LfaZ3RDhgyJuve///1Rd9ddd0Xd/Pnzo86a9tbwl6gAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCq+/tJ8Bfp6enJ+pWr14ddbfddlvUPfnkk1G3ffv2qFu6dGlVH69cLkddXV1d1M2cOTPqvvnNb0bdQQcdFHXTp0+PulmzZu20WbRoUfRYnZ2dUUffkr6X995776i7+OKLo+7DH/5w1I0dOzbq0t8jXfu6urqibtu2bVHX1tYWde3t7VFXKpWiLrVly5aoS59f+u8Bb4aGhoaoSz+jP//5z0fdscceu9Omtjb7/wcLFiyIukceeSTqli1bFnXpfmnGjBlRd95550XdGWecEXXp2vyZz3wm6jZv3hx1UFOTf/amn4EtLS1RN3Xq1Kjbf//9o27o0KFRt379+qjbtGlT1KXX77p166Iu3dOlGhsbo27cuHFRd8wxx0Tdhg0bou6ee+6Juueeey7q0j0dpNJraMSIEVF30kknRd0555wTddOmTYu6YcOGRV0q3Vv96U9/irqf//znUTd//vyoS9eCSqUSdbAn6devX9Ql94E1NTU13//+96NuzJgxUffSSy/ttLn22mujx3rqqaeiLt1HvvOd74y69LMjPVNLz/WtaXu29H11yCGHRN1FF10Ude95z3uiLt0L1ddnX71W+6w7PSdJ79vSdWPUqFFRN3z48KhLvveqqampuffee6MOekt6FpWuBa2trVGXfvamj5feF73++utR9/LLL0fdmjVrom78+PFRl+5x0rUv/f7zgAMOiLpnnnkm6qp9psZf5i9RAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhVbf20+Av05PT0/Ubd++PeqefvrpqHvmmWeirqurK+q6u7ujrtrq67O3/tKlS6Nux44dUVdbm80t1tXVRV36e7Dnampqirqjjjoq6s4666yoGz16dNSl7/n0GnryySej7rHHHou6xYsXR93atWujLr12R40aFXUHH3xw1KVr6bp166Kuo6Mj6mBXpOvByJEjo+6d73xn1I0dOzbqks/8O+64I3qsG2+8Meo2bNgQdeVyOeoqlUrU3XnnnVH36KOPRt0Pf/jDqDv11FOj7uijj466u+++O+rSfTN7tlKpFHUDBgyIumnTpkXdhRdeGHUnnHBC1A0ZMiTq0t+3s7Mz6tLrKF3r0+eXPl5639vS0hJ1zc3NUffcc89F3UMPPRR1UG3pNTRmzJio+9rXvhZ17373u6MuvZ9ta2uLui1btkRdumfq169f1J1xxhlRN2XKlKj75Cc/GXUvvPBC1KV7SdgdpNfl7Nmzo+7HP/5x1I0YMSLqfv/730fdt7/97Z02q1atih4r3VcddNBBUbfXXntF3aZNm6Ju48aNUZfuS9M1nL4lPTOdOXNm1H31q1+NuhNPPDHq0vvAVPr9WHqdz5s3L+puv/32qFu9enXUnXPOOVH3kY98JOoaGxujLj07T/e60FvS722WLVsWdbfddlvUTZ06NerS+4knnngi6l5++eWoS78P7N+/f9Sl92Nnnnlm1KV7q3RPkt6PpT+Xt4ZPGAAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNDqe/sJ8OYql8tR197e/iY/k7+sUqlEXalUirra2mwucPjw4VH3oQ99KOoOO+ywqEuf35YtW6Luueee22nT09MTPRZ9S/qeb2xsjLoRI0ZEXXNzc9Sla0tHR0fUzZs3L+quuuqqqFu2bFnUNTQ0RN2gQYOibvz48VE3YcKEqBsyZEjUbdq0KerWrVsXdd3d3VGXruGwK5qamqIufd/PnTu3at2CBQuix0o/x9NrrdrStTl97R5++OGoO/PMM6Pu/PPPj7o//vGPUddb+1x2T3V1dVE3evToqJs8eXLUpWtfV1dXVbv0XiHt0j1s+nitra1Rl+7Vhg0bFnXpHmfp0qVR9+qrr0Zd+u8GqQEDBkTdJz/5yag777zzoq6zszPqfve730Xd9ddfH3Wvv/561NXXZ8eh06ZNi7pPfepTUZfeB5588slRt2jRoqhL79+hN6V7sEmTJkXdN7/5zagbNWpU1N1yyy1R97WvfS3q0vOZxNChQ6PuggsuiLqpU6dG3W9+85uoW7FiRdSl+yBnUbun9H160UUXRd3RRx8ddf3794+69P5k8+bNUTd//vyoS6+j9NxlzZo1UZd+T3XUUUdV9fFS6XWefnZAb0nXlsWLF0dd+v1YKj0jTu/v0jOhdG1O932XXHJJ1A0ePDjqUhs3boy6dC/k+/y+xV+iAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACq2+t58AfUOpVIq62tps7q6uri7qGhsbo27o0KFRN3v27Ki74IILou7444+PugEDBkRdW1tb1P3qV7+KuhdeeGGnTblcjh6LvqVSqURdZ2dn1C1ZsiTqXn755ahraGiIuvT9t2PHjqibOHFi1I0bNy7qjjzyyKibPn161I0dOzbq0rWvp6cn6latWhV1a9asibply5ZFXXt7e9Sl79P0fc/uKf33XbduXdT99re/jbp077Jhw4adNh0dHdFjpddub0n/LVpbW6PugQceiLozzzwz6mbOnBl1LS0tUZeuVezZ0vd9V1dX1G3ZsiXq5s+fH3UPP/xw1KV7tcWLF0dden2k9zHp+pfuEUeMGBF13/rWt6Ju3333jbqVK1dG3TXXXBN1q1evjjr3bqTSM5dDDz006s4///yoS6/xyy+/POquvvrqqEv2aTU1NTXd3d1Rl56BrV27NupOOOGEqEvvK0ePHh116e8Bu4N0XUvPatPr7dVXX426H/3oR1G3cePGqEv2pv37948e6/3vf3/UnXXWWVH30ksvRd1dd90VdVu3bo26vn4fzV+Wfhal+/rx48dX9eem9zHpmemcOXOi7qabboq6p59+Ouq2bdsWdakhQ4ZE3bRp06IuXcPTvZr7J/YU6WdbejaTnk2na2Tapd9nTZgwIerSPcnf/M3fRN3kyZOjLl2r0tf5sccei7r0+1l7ob7FX6ICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKrb63nwBvrsbGxqgbNWpU1B100EFRd8QRR0TdjBkzom7mzJlRN3bs2Kjr169f1JVKpahrb2+PuhtuuCHqfvGLX0Tdtm3bdtpUKpXosdg9dXR0RN0TTzwRdf/5n/8Zde94xzuibuLEiVE3cuTIqDvvvPOibsSIEVXtmpqaoq6+vnc+VgcOHBh1//N//s+oS9fcf/u3f4u6+fPnR11nZ2fUWdd2T+m/244dO6KutbW1qj/X++r/Vi6Xo27RokVVfbx0bR46dGjUrVmzJurYs6XXeFdXV9QtXrw46rZs2RJ1a9eujbqNGzdGXV9fI+vq6qJu+PDhUZfef6a/x29+85uoe+yxx6Iu3bNDqn///lF34YUXRt2QIUOi7tFHH4269Ewj/YxO9xDpNV5bm/2f0vTnjhkzJurSM7p0re/p6Yk62B2k12V6fpSe6S5cuDDqVq1aFXXpdZms4+eff370WJ/97Gejrq2tLep+8pOfRN0rr7wSden+mj1betaT3meln72rV6+Ouj/84Q9Rd//990fda6+9FnXpdZnucdK1L937HXrooVGX3t+l96lLliyJuu7u7qiDvq7a13hDQ0PUpd+pf/jDH466d77znVG33377Rd2gQYOirtr3d+l96n333Rd16f2d7yf6Fn+JCgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLT63n4C/HelUinqGhoaou7www+Pus985jNRd9RRR0Xd0KFDo66xsTHq6uur+1atVCpR19PTE3WbN2+OukceeSTq1q1bF3Xp82PPVS6Xo27jxo1R96c//SnqXnvttag79thjo+7AAw+MuhkzZkRdv379oq6rqyvq0mst/ffo7OyMulRzc3PUDRo0KOpOPfXUqBs2bFjUfelLX4q6Z555Juqq/frRt6Sf0WnHmy+9JtN/s7q6uqjr7u6OOtgV6ftq/fr1UZfeJ7S2tkZdunfp62tkunf5l3/5l6hL9yRLliyJumuuuSbqduzYEXWQSs+ERo0aFXWzZs2KuvS9fP3110fdmjVroq6vf5YPHjw46tL71HRtfvbZZ6Our79+sCvS62PlypVRl+6Z0ut3//33j7pXX3016k444YSdNl/72teixxowYEDUXX755VH38MMPR117e3vUsWdLr93Vq1dHXfo+ve6666Juw4YNUZfe33V0dERdekZcbel5SnpmP27cuDfydP4v6fvgqaeeirreep2h2tL7wPQaHz9+fNR96lOfirr3vve9UTd8+PCoq/Z3/tX+/m779u1Rl37v2tfP6PjL/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0Op7+wkURalUirq6urqoGzlyZNR96EMfirrjjjsu6oYPHx51tbXZfF76ulQqlajr7u6OunK5HHXp8xsxYkTUffrTn466V155Jeoee+yxnTadnZ3RY7FnS9/zGzdujLq2traoW79+fdQtWrQo6pYtWxZ1Bx10UNQNGDAg6lpbW6PumWeeibqXX3456tLPhPHjx0fdWWedFXUzZ86MulmzZkXdl7/85aj75Cc/GXWrVq2KuvSzA3hjGhsbo66hoSHq0s+OHTt2RB3sip6enqhL90LV/rl9/bMtvQ88/fTTo+6YY46JuvSe5ytf+UrULV26NOr6+r8Hu590/7/XXntFXf/+/aMuvc966qmnoq6rqyvqekt61rP33ntH3ZgxY6Ju27ZtUffiiy9GXfrZAbuD9Ez3gQceiLrFixdH3eTJk6PuG9/4RtQtWbIk6k455ZSdNukafuONN0bdz3/+86hzn8WbId0bpPvwan+vlOqt/X/6+w4cODDq3vOe90RdenaeruEPPvhg1K1YsSLqoGjStWDYsGFRN2nSpKjr169f1KU6Ojqirr29Perq67Nxl/QMe/To0VG33377Rd2cOXOirrc+2/jL/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0Op7+wnw35VKpairq6uLutbW1qjbtGlT1NXXZ2+Z9PfYvHlz1L366qtR99xzz0VdV1dX1B122GFRd8QRR0Td9OnTo+5zn/tc1F1yySU7bTZu3Bg9VqVSiTp2T+m/b7lcjrq2traoW7VqVdR1dHRE3Zo1a6JuyZIlUTd48OCq/txnn3026jZs2BB13d3dUVdbm81E//GPf4y6f/qnf4q64447LuqOPfbYqna/+93voi59/dg9pXuNVHIdpT8z7dK1udpdqqmpKepOOeWUqEv3kc8//3zUbd++PepgV6TXUU9PT1Ufb08xZsyYqPvyl78cdel97y233BJ1c+bMiTp7CPq6/v37R93rr78edeln77p166Kur0v3JCeeeGLUNTQ0RN2CBQuibu3atVEHe5L0PCpd1370ox9FXbonmTlzZtSlZ8TJOvSHP/wheqyf/OQnUZee/0Nv6q3zj2qr9vlRuvc788wzo2727NlRl545b9myJepuvvnmqEu/e4A9RbW/v1u9enXUPfDAA1GXPr+BAwdG3cqVK6Nu2bJlUXfGGWdE3YwZM6Kuubk56qZMmRJ16f0nfYu/RAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRafW8/Af67np6eqNu0aVPUXXfddVH34osvRl1LS0vUbdiwIeqeffbZqFu/fn3Utba2Rl1q3333jbp///d/j7rDDz886o4++uioO+igg3baPPjgg9FjlcvlqGPPVqlUoi59v3R2dkbdli1boq65uTnqduzYEXXd3d1R99prr0Xd6tWroy59fulnQqlUirqFCxdG3dVXXx116Zo2cODAqDv55JOj7o477oi69N+Xt0ZtbTa739TUFHX9+/ePuqFDh0bd3nvvvdMmfW6NjY1R197eHnXpWrp8+fKoS9egiRMnRt35558fdV1dXVF37733VvXx4M2Q7pn2FOm69uEPfzjqpk6dGnUbN26Muu9973tRl65/0Nel9x1333131KVnM9u2bYu63loj0/ui9L7ytNNOi7r097399tujLt37QRGl18fjjz8edS+88ELUpWfE/fr1i7rNmzfvtEnvi1auXBl16RkT8P+W7jXS86P0+7Zjjjkm6v7+7/++qj83XTfStTQ9Y0/PEBsaGqIu/T3Srtp73aKdL/DXS9+jq1atirpf/epXUZfeV6bPr6OjI+rGjh0bdbNmzYq6dA2vr8/GZ9K1Kv259C3+EhUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBo9b39BPjvSqVS1HV0dETdSy+9VNWup6cn6srlclW7SqUSdenrV1ubzQ8uWbIk6v74xz9G3SGHHBJ1gwcPjrqTTjppp82f//zn6LHSfwt4MzQ1NUXduHHjom7ChAlRt2bNmqhbt25d1LW3t0ddupama1/adXV1Rd2yZcuibsuWLVE3aNCgqJs8eXLU1dXVRR1vjfSzd8SIEVF3zDHHRN20adOiLv3sHT169E6b+vps6zxgwICoS6/dzZs3R90LL7wQdcuXL4+697znPVGXrs1r166NupdffjnqGhoaoq67uzvq0r1Q+p6v9hoOb4b0/bzffvtF3Sc+8Ymq/twf//jHUZeuf643+rr0s+iVV16Juk2bNkVduq9P73f6+rWW7PtqampqJk2aFHVbt26Nurlz50Zder8IRZSe6Q4bNizqhg8fHnXpPUVbW1vUJecz6RmONQPeuHRtSb+3mTJlStS9+93vrmqX/tz0bLWzszPq0u8rjzvuuKgbM2ZM1KV7sG3btlW1Sz8TduzYEXXpZ4f1/s2XnlWkqn1fVO3vgVavXh116ZluurYMHDgw6o488sioO+CAA6IufX7pmpa+Lunj9fX76KLxl6gAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCq+/tJ7C7K5VKUVdfn73UjY2NUVepVKKuu7u7ql36c9Ou2qr9/Kr9OqfS91Vzc3PVHgt2Rfq+Ste08ePHR93RRx8ddYccckjUPfnkk1E3b968qOvra2RPT0/UdXR0RF36e9TWZjPbLS0tUdevX7+o27ZtW9TxxjQ1NUXde97znqh7//vfH3UbNmyIupdeeinq7r777p02XV1d0WOl3aBBg6Ju2LBhUXfYYYdF3RlnnBF1e+21V9SlXn311ahLX5fhw4dH3aZNm6Kuvb096tLPwHR/WC6Xo663PjvYs6WfqV/4wheibvTo0VG3YMGCqLv22mujrrOzM+qgr0vX+vQza/Xq1VG3p3wWpfcdb3/726Nu8ODBUZfeLy5fvjzqoIjSPXa61/jYxz4WdVOnTo26xYsXR126txo7duxOm/SMJF37oIjS6yM9dznyyCOj7pJLLom6WbNmRV36/BoaGqIule790rP4GTNmRF16f7d+/fqoe+WVV6raLVq0KOoee+yxqHv99dejrrW1Ner6+p69N9TV1UVd+l1+tc8G0+9tqv1vW+3HS/dBxx57bNSlZ1EjR46MutTGjRujbu7cuVGXft9G32KHDQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFFp9bz+B3V2pVIq6IUOGRN3UqVOjrrY2m39bsmRJ1G3atCnqOjo6oq5cLkddtaX/Ho2NjVE3adKkqDv99NOjrr4+u+S6urqi7vXXX99pU6lUoseCN0N6rR144IFRd8opp0Td6NGjo2779u1RN2jQoKirq6uLuu7u7qir9vWb/ntMnDgx6tLPtvT32Lp1a9R1dnZGHW9M+pk6ePDgqEuv3xEjRkTdddddF3W33XZb1G3bti3qEulrN2DAgKhL18gTTzwx6tJrN933rVy5MurS/eHb3/72qEtfv2eeeSbq1q9fH3XpGpSufT09PVV9PKipydehGTNmRN2ZZ54Zden18b3vfS/q0uvS9UHRpO/59L5jT9HU1BR1F1xwQdSla+ntt98edTt27Ig6KKL03OWss86KuvSsdu3atVF3+eWXR136/PbZZ5+dNukZU2+dw0NvSr9nGTt2bNS9973vjbqLL7446pJrvKampqZ///5R19DQEHXp3iXdS6bfQ6Zng+nzS7sxY8ZE3bRp06Ju8+bNUbd48eKoGz9+fNTdeeedUffcc89FXW9991Bt1fy+d9SoUdFj7b333lGXXhtr1qyJuvR7qvb29qhL9wbp2pKuaR/84Aej7sILL4y6dA1P90xtbW1R97vf/S7qnnzyyaizV9s9+UtUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodX39hPY3dXWZnNoY8eOjbrzzjsv6lpaWqJu/vz5UXfvvfdG3erVq6OutbU16srlctSlr3P//v2jbsaMGVH3xS9+MeoOOeSQqEt/j/Xr10fdvHnzdtr09PREjwVvhsbGxqgbN25cVbt0jUzX5pEjR0bda6+9FnVdXV1Rl16/dXV1UTd69Oio++AHPxh1gwYNirp0rX/kkUeirrOzM+p4Y0qlUtT169cv6pqamqIufb9UKpWoS59fe3v7Tpv0WkvXjCOOOCLq0msy3Y+8/vrrUXfXXXdFXbr2HXnkkVGX7tPSNSh9Lz/zzDNRt27duqjr6OiIuvS9DLti4MCBUfeVr3ylqo/35z//Oermzp0bdelnAkBNTU3N/vvvH3UHHXRQ1G3dujXq/vCHP0Sd8xmKKL2HmjZtWtRddNFFUdfQ0BB1V111VdQ9//zzUfd3f/d3UZfcAyxfvjx6LPsl9iTp9yeDBw+OurPOOivqPvGJT0RdejZdX5999Zqukem5RrrXSM7Aamqqf/5R7bPG9LuHanfDhw+PugkTJkTd0KFDoy69PvYU6Vlycg9w7rnnRo91wAEHRF167a5ataqq3fbt26MuPTOdNGlS1KVnuukamX6Xn64Z6fdF6ZlVuj/cvHlz1Dn73T0Va8UFAAAAAAAAAAD4/zFEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqvv7Sewu6tUKlFXV1cXdZMmTYq6mTNnRt3s2bOj7pBDDom6OXPmRN2KFSuirr4+ewuOGTMm6o455pioO+2006Ju/PjxUZf+Hu3t7VH3s5/9LOpeeOGFnTY9PT3RY8GuSNe+tra2qOvs7Iy6AQMGRF3//v2jbp999om6gw8+OOrWrl0bdelnQrq2pL/HRz/60ag744wzoq62NpvFfu2116LuzjvvjLr0/cIbk17nW7ZsibqHH3446oYNGxZ1Z599dtSle5z169fvtBk3blz0WFOnTo269NrdsWNH1N19991R9+///u9Rt3z58qhLrVy5MupOOeWUqBs1alTUpa9zulYl75Wamvwagl2Rfvam94tHH3101HV0dETd97///ajbtGlT1AHU1NTUNDQ0RN173/veqGtubo66Rx55JOqWLFkSdVBE6fnMmWeeGXUTJ06Munnz5kXdQw89FHXHHXdc1KVn+8nZ+aOPPho9Vnd3d9TB7iA9Cz3ooIOiLj0LTc8N0j1JqVSqapd+x7Nx48aoS7/nS89q0/OU9PUbNGhQ1E2ZMiXqhg8fHnXpdw/pv1vy/V1NTf596p7yXV96rpGeESd7iPPPPz96rJEjR0ZdqqurK+rS7zvSNTK9hpqamqIu/T4rvTZS6Xfq9957b9R997vfjboXX3wx6srlctSxe/KXqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEKr7+0nsLvr6emJuhUrVkTdsmXLom727NlRN2bMmKgbP3581L3rXe+Kuo6Ojqirq6uLun79+kVd//79o66+vrpv/e3bt0fdDTfcEHW/+MUvom7r1q07bSqVSvRYsCvS91V7e3vUPfjgg1H30Y9+NOqGDh0adena9z/+x/+IumnTpkXdxo0bo26vvfaKukMPPTTqJkyYEHVNTU1Rl6xBNTU1NT/72c+i7plnnom6crkcdbwx6XVe7c/A9PEOOOCAqEvf9/vvv/9OmyFDhkSPtXnz5qi77777ou7mm2+OukcffTTq0ms3vdbS/dxTTz0Vdek+LX0PrF+/Puo2bNgQdelnW1dXV9TZq7ErBg4cGHXp3mXQoEFR9+c//znqHnvssahL76MBamry+7tzzz036tI9zk033RR16RkY7ElKpVLUDRgwIOrSvX36c5csWRJ16Rn7pz/96ahL15crrrhip82qVauix3I/we4gvXbT74GOPfbYqEvPfhsaGqKutra6f5eiu7s76tLvFy+//PKou+WWW6IuXYfS3yO9D0zPmebOnRt16fsvfR+k79P0565duzbq0td5T/lcSM8HW1paqtLU1ORnLul7tNrS91TaVVu117Trrrsu6n75y19GXTqDkf4e7Nn8JSoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQ6nv7CezuKpVK1G3cuDHqrr766qgbPXp01J188slRN3jw4KgbNmxY1JVKpahLX79U+nhdXV1Rt3Tp0qj7+c9/HnW//vWvo27t2rVR19PTE3XQW7q7u6PuxRdfjLobbrgh6j772c9G3cCBA6Nu0qRJUbfPPvtEXaq2Npt1Trt0jdy6dWvUXX/99VGXrpFtbW1RR99SLpejbvny5VF37bXXRl3//v2jbuTIkVFXX7/zbXH6ubt+/fqo27ZtW9S1t7dHXfpv0Vv7r/R1efrpp6Mu/YzZtGlT1G3evDnq0n8P+zR2RfpZfuCBB0bdqaeeGnXpdXTVVVdFXbqHAKipqampq6uLutmzZ0fd3nvvHXXpnuT++++POp/58P/W1NQUdQ0NDVGXrhvveMc7ou5d73pX1DU2NkbdNddcE3U33XTTTpvOzs7osWBPkl5rLS0tUZfeZ6XSz/z03ODxxx+Pussuuyzq7rvvvqjbvn171KXnTNWW3qd2dHREXfp9Zaraj1e0vWR6jrhly5aoW7BgwU6b9DvX9LvydD9S7TUolb6n0u/K0/unefPmRV36Pd8DDzwQdRs2bIi6ol1rvDH+EhUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBo9b39BIqiu7s76l544YWo+8xnPhN1xx9/fNSdeuqpUXfooYdG3ciRI6OuVCpFXWtra9Slr98999wTdffdd1/Uvf7661HX1tYWdZVKJeqgr0vfy9u3b4+6q6++Oup6enqi7m//9m+jLl3TGhoaoi6V/h7pGrlo0aKou+yyy6Lu1ltvjbrNmzdHnbVvz1Yul6Nu27ZtVe3WrVsXdQnv0b8sfV26urqibu3atVE3f/78qKv2Z1G6r4dd0dzcHHUXX3xx1A0ePDjqFi5cGHUPP/xw1KVrPUBNTU3NwIEDo+6iiy6Kuvr67JjzoYceirqVK1dGHRRRusdOzwOeeuqpqHvb294WdaNHj466jRs3Rt3Pf/7zqLviiiuibsuWLVEHRZOeG7zyyitR99JLL0Xd3nvvHXXpGdPNN98cdTfddFPUpd8/dXZ2Rl3RVPs8z/ngG5O+funZ7x133LHTJr023ve+90XdjBkzoi6930nXvvQ1efLJJ6PugQceiLp58+ZF3YoVK6Iu/T4rfV1ck7wZ/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0EqVSqXSKz+4VOqNH8sb1Nf/3Xrp7Qy8RWprs9nflpaWqJs5c2bUnX/++VF3xBFHRF1TU1PUrVy5MuruueeeqPuv//qvqFuzZk3UdXd3Rx3ArkjX+rq6uqp2XV1dUdfT0xN19qXU1OTv5/333z/qbrjhhqjbZ599ou773/9+1P3oRz+Kuh07dkQdb430/t16RbWla9/UqVOj7rbbbou6UaNGRd0ll1xS1Z/b2dkZdVBE6XowevToqDvjjDOibu+99466O+64I+oWLVoUda2trVHnsxf+snT/2tjYGHXpGeyAAQOiLr3faWtrizpnq/DWSNeWdN+SrkHlcjnq0rPGanewO+itfbO/RAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRafW8/AXYvlUqlt58CUGA9PT1Rt2nTpqj705/+VNUuVSqVqvp4KWs4sDtI1/q06+rqeiNPB96QhoaGqDv44IOjbsiQIVG3evXqqHvkkUeirru7O+roW+z96C319dlxY7r2DRo0KOpWrlwZdUuXLo26dK8B/L+l19GqVaui7he/+MUbeTpAH5fuXzs6Oqrabd26NeqA3VO6tpTL5ahra2t7I08H2A34S1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAECh1ff2EwCAoqlUKr39FACAt0CpVIq6tra2qHvhhRei7plnnom6RYsWRV25XI46gJqa/H5n06ZNUffEE09E3dy5c6NuyZIlUWftAwAAgOLxl6gAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCK1UqlUqv/OBSqTd+LADAmyrd4/TSFgyAt1Btbfb/lhobG6Ouf//+Udfe3h51nZ2dUdfT0xN1PtuAXdHQ0BB16VpaLper2lnTdk/uxwAAAHpHte/Heuu+zV+iAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoZUqlUqlV35wqdQbPxYAAAAAAAAAAOijemmUyV+iAgAAAAAAAAAAis0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACq2+t58AQF9WKpWirlKpvMnPhJqa/N+jr/+7pc+vr0tfP9fHG9PX389A32LNAAAA6B3ux4A9jXWN1J7yvVfKe37P5i9RAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhVaqVCqVXvnBpVJv/FgAdmO1tdnsb/oZk3bpR2W1u1QvfZQDAAAAAACwh0q/R6urq6tq19PTE3Xlcrmqj0ff0lvff/pLVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHV9/YTAID6+uzjaNSoUVF39NFHR92+++4bdevWrYu6F154IepeffXVqNuyZUvUdXV1RV1PT0/UVSqVqAMAAACg95RKpao+njMhACiG9Hu5MWPGRN2HPvShqJs+fXrU3XPPPVF35513Rt3WrVujzl6Imhp/iQoAAAAAAAAAACg4Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACi0+t5+AgDsuerrs4+ZUaNGRd2pp54adRdddFHUTZ48OerS32PVqlVRd/vtt0fdf/3Xf0XdsmXLoq69vT3qKpVK1AEAAACwa2prd/5/25OmpqamprGxMep6enqirru7O+rK5XLUOWOC/7dSqRR1DQ0NUdfS0hJ1++yzT9Sl13l6Nr1t27aq/lzgL0vXlmHDhkXdF77whag777zzom716tVRd88990SdvQZvBn+JCgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLT63n4CAOx+amuzGdzGxsaoGzJkSNQNHTo06np6eqKuoaEh6gYNGlTV7uKLL466kSNHRt2VV14Zda+88krUdXR0RF2lUok6oG+pq6uLunQN79evX9SVSqWoa29vj7rOzs6o6+7ujjrgrZOuB/Yau5/0PiHdrwNAX5DuXerrs69bWlpadtqkZ0wDBw6MuvT+adu2bVG3devWqEvPmNL7NvtDdgfpuUt61n3UUUdF3cc//vGomzx5ctQ9//zzUXfFFVdE3WOPPRZ1ra2tUeeeAv6y/v37R93HPvaxqDvvvPOirlwuR931118fdY8++mjUpWfJsCv8JSoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQ6nv7CQBUU6lUirpKpfImPxNqampqenp6om7Lli1R98ILL0RdXV1dVX/ugQceGHWjRo2qavf+978/6kaMGBF13/zmN6PulVdeibpyuRx1wBvT2NgYdWPHjo26973vfVF3zjnnRN24ceOibtu2bVH3+9//Pup+9atfRV362dHe3h519hDw/1Zbm/0/rbRL9xquy7+svj478unfv3/UJXv79N8sXXPZs6X37+n9XXr/mXZ9Xfr6VZs1lyJqaGiIuvTeaMaMGTttJkyYED1Wek12dnZG3caNG6Nu3bp1UbdixYqoW7NmTdS1trZG3Z6y1tO3pJ+9zc3NUXfcccdF3Ze+9KWo23vvvaMuXQ+GDBkSdf369Yu6dE9nrwF/WXqPP3v27Kj727/92zfydP4vV155ZdRdf/31UZfuSbq7u6PO2sKu8JeoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqvv7SdA31AqlaKutjabu6t2V6lUoi5VLpejrqenJ+qq/fz46/m3eGukr3N3d3fUbd68OeqeeeaZqFu2bFnUPfTQQ1F30EEHRd0pp5wSdccee2zUDR06NOpOPfXUqFu4cGHU/eQnP4m6rVu3Rh0UTbqvam5ujrpjjjkm6r74xS9G3cEHHxx1jY2NUVft3zddI9M1/JVXXom69vb2qIMiSteDpqamqOvq6oq69L6taNJ/j2nTpkXd0UcfHXX333//TptVq1ZFj2XN3bOlZz3p3mDixIlR19HREXXLly+Pura2tqir9jlEQ0ND1KX3iy0tLVG3ZcuWqNu4cWPUpecBznHoTXV1dVE3efLkqHv3u98ddccdd1zUJdIztfQaT/cZabd69eqoe/zxx6Nu7ty5UZeuVfab7Ir6+uwr1XQf/tnPfjbq9tprr6h77bXXom7t2rVRl+6FBgwYEHXpfaC9AUWTnq2OHj066v7xH/8x6gYPHhx1t956a9Rdc801Ubd+/fqo6+zsjDprBm8Gf4kKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAotPrefgK8uerq6qKuubk56kaPHh11kyZNirrDDjss6qZNmxZ1w4cPj7qnnnoq6u69996oW7hwYdRt2bIl6iqVStRBb0nfo+VyOera29ujrqOjI+o2btwYdY2NjVG3dOnSqHv44Yej7h3veEfUfeYzn4m6dO37m7/5m6i74447ou7ZZ5+NOmsae4pSqRR1w4YNi7r0mvy7v/u7qBsxYkTUtba2Rt2iRYuiLn1d9tlnn6jr169f1KW6u7ur+niwO6itzf6/1JAhQ6LugAMOqOrPTfcQ6d6vr0vXyXT9S++jP//5z0ddV1dX1N133307bTo7O6PHYs+WvpePPfbYqHvf+94Xdc8880zUJe/lmpqamiVLlkRdulal95/pGdiFF14YdQ0NDVF38803R90TTzwRdel5gPtF3gzpZ+/IkSOjLr13O/vss6Ouvn7nX8usWrUqeqz0vLmlpSXqBg8eHHXpWdQhhxwSdSeffHLUTZ8+Pep++tOfRt3q1aujjj1beh+TnvdceumlUTd16tSoW7NmTdTNmzcv6tK92n777Rd16feG6doMRZPsC2pqampOOeWUqEs/ezdv3hx1V155ZdStXbs26tKzWvcJ9CZ/iQoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACi0+t5+Avx1amuz+bdBgwZF3eGHHx51H/nIR6Ju9uzZUTds2LCoq6uri7r0dZk1a1bUnXTSSVH3xS9+MermzZsXdd3d3VEHfV2lUom6crn8Jj+Tv6yrqyvq2traom779u1Rd8stt0TdEUccEXXvete7om7s2LFR9+53vzvqnnvuuaizprGnaG5ujrr0mvxf/+t/RV1LS0vUvfbaa1F39dVXR93ixYuj7r3vfW/U7bvvvlHX2toadenv29nZGXXpZxb0plKpFHV777131F100UVRN3ny5KibM2dO1M2fPz/q+rr0/nPAgAFRl95Hf+ELX4i6vfbaK+p+97vfRd3KlSt32qT7a3ZP9fXZMWK6Zlx66aVRd+CBB0bd4MGDo+7VV1+Nuq1bt0ZduneZOHFi1H3sYx+LuvTMasGCBVHX3t4eden9u70VvSm9dzvttNOi7v3vf3/UpevQqlWrdtq8/PLL0WOtW7cu6tI1fO3atVG3Y8eOqDvggAOibsKECVF34YUXRt0TTzwRdffcc0/U9dbZJW+NhoaGqDv++OOj7sQTT4y69Mx57ty5UZe+70844YSoGzduXNTNnDkz6tK1Od1b2Wuwp0jPfj/1qU9FXbqm/eY3v4m6Z599NurS74Fcu+wO/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0Op7+wnw35VKpahrbGyMuqlTp0bd5z73uaibPXt21FUqlahbs2ZN1G3atCnq0tdl3LhxUTd58uSomzVrVtQ99dRTUdfd3R11wBuTrlXlcjnq2tvbo2758uVRd+2110bdaaedFnUDBw6MurPOOivqfvCDH0Td9u3bow56U7IHS/cPH//4x6OupaUl6hYvXhx13/rWt6Ju/vz5UXfAAQdE3RFHHBF19fXZrce8efOibtmyZVGXruHQm2prs//fNHbs2Kj73ve+F3WHHHJI1D366KNRt2DBgqhra2uLunSvlkrvt5uamqJu+PDhUXfRRRdF3Uc+8pGoS5/fgw8+GHW//e1vo66jo2OnTU9PT/RY9C3pGjRy5Mio+4d/+IeoO+6446IuPSPp7OyMuvT3HTp0aNTtvffeUXfuuedG3Tvf+c6oS/dW6d4v3Vulr3O113Coqck/A4899tio+9KXvhR1I0aMiLr0DHvu3Lk7bdL914YNG6IuvSZ37NgRdek5/Mknnxx1H/zgB6Nu1KhRUZe+B+bMmRN17it3T+n+f/To0VF36aWXRl3//v2j7ne/+13UpWfE27Zti7rm5uaoS7/3OuaYY6Ju+vTpUZeua65L+rq6urqoS89m0u+s161bF3XXXHNN1LW2tkad/T97En+JCgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLT63n4C/HX69esXdaecckrUzZw5M+o6Ojqibs6cOVH3s5/9LOrWrVsXdQMHDoy6f/iHf4i6t7/97VF3+umnR90vf/nLqGtra4s6oG+pVCpR193dHXULFy6MulWrVkXdfvvtF3Xjxo2LuvHjx0fdCy+8EHXQm0ql0k6b9NrYZ599oq69vT3qrr322qh7+OGHo66pqSnqPvCBD0TdhAkToi5dq377299G3ZYtW6IuXZvhzVBXVxd1e+21V9R9+9vfjrqTTz456hYtWhR1P//5z6Nu8eLFUVcul6MuWZtrampq6uuzo430PnratGlR94//+I9RN2vWrKjr6uqKunvvvTfqrr766qhbsmRJ1CX/btbc3VN6lnLRRRdF3Zlnnhl16bX7xBNPRN11110Xdel9VkNDQ9TNnj076s4555yoGzZsWNQ9++yzUZfurTZu3Bh1PT09UQe7orGxMeqOPvroqPvBD34QdZMmTYq69Ez8wQcfjLrbb799p83y5cujx9q0aVPUpfuvdD9SW5v9//x0zUj3rxMnToy69D41Xes7Ozujjr4lvR9LvwdK14ylS5dG3VVXXRV1L7/8ctSl1/mOHTui7rjjjou60047Leo+97nPRd38+fOjbuvWrVEHvSXd33zwgx+s6uM999xzUZeuVfb/FJG/RAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRafW8/Af67UqkUdQMHDoy6GTNmRF1DQ0PUPfnkk1H3L//yL1G3ZMmSqEsNGzYs6l5++eWoO+GEE6Ju3333jbohQ4ZE3aZNm6KuUqlEHfDGpGtzKr12t27dGnUrVqyIusmTJ0ddY2Nj1I0fPz7qXnrppajr6emJOngzJNd5fX22da6rq4u6jo6OqHvssceirrOzM+qOPfbYqDv99NOr+nN//etfR93ChQujrru7O+rgzZDeP+23335R981vfjPqTj755Khbu3Zt1P3v//2/o+6JJ56Iuvb29qhL1dZm/+9r8ODBUXfeeedF3aWXXhp16V4ovb+78cYbo+6GG26IuqVLl0Zd+u/m/nP3k65VRxxxRNR9+tOfjrr+/ftH3SOPPBJ1X//616NuwYIFUVcul6NuzJgxUTd79uyoGzlyZNTt2LEj6n76059GXboW2FvxZkjvjQ4++OCo+9d//deomzJlStSl7/t58+ZF3fXXXx91yXq1ffv26LHSz/F07UvPwNLPmFRzc3PUpc9v/fr1Uecsas+W7klOPPHEqv7cdL++ePHiqKv2fj29X7zsssuibtq0aVF30EEHRd2pp54adTfffHPUuc7pLQMGDIi69Lv89Bp/9NFHoy4904Ui8peoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqvv7SfAX6dUKkVdW1tb1G3dujXq1qxZE3Xd3d1RV1+fvQWbmpqibuLEiVE3bty4qEtf59rabB6xX79+UQe9JX3Pp11v/dy6urqqdpVKpapd+nsMGTIk6lLVfp0HDhwYdela39XVFXWp9N8Damqy98umTZuix+rs7Iy6/v37R90+++wTdem+7xvf+EbUNTc3R92cOXOi7rrrrou6zZs3R51rnDdDujeYPHly1P3whz+MuiOPPDLq1q1bF3Xf+ta3ou7hhx+Ouvb29qhLr8v0dR4xYkTUXXLJJVH3kY98JOrS9W/x4sVRd+ONN0bdHXfcEXWvv/561HV0dESd9XT3k+7Xx4wZE3Vf+tKXom7o0KFR99prr0Xd1772tahbsGBB1KV7sPSM6fDDD4+6k046KerSs6OHHnoo6u69996oq/YaDjU1+ft55syZUXfFFVdU9fF6enqi7umnn466f/7nf466dL3atm3bTptyuRw9Vvq7ptd4+m/b2NgYdbNnz466UaNGRV26v3n00UejLv0eg74l3QsNGzYs6qZOnRp1K1asiLrbbrst6nbs2BF16XWeSt/3zz33XNRdfvnlUff1r3896j73uc9F3YMPPhh1a9eujTqotvS+I/0eKN0bpNduqre+v0v3JOkep7f2Vuye/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0Op7+wnw31UqlajbsmVL1D311FNRN3PmzKibMmVK1J1//vlRt3jx4qgbMGBA1I0fPz7qRo4cGXXpv0d9fXYpNTQ0RF2pVIq69PlB+p5K38sDBw6MuqFDh0Zdek3uv//+UbfPPvtE3aBBg6IuXXO3b98edStWrIi6yZMnR136uqRrRvp7tLe3R11TU1PUpdLfo1wuR11PT88beTrsIZL31erVq6PHWrlyZdQdcMABUfexj30s6tra2qJu3333jbpVq1ZF3eWXXx51y5YtizrXJG+GdC80evToqPvmN78ZdbNmzYq6tWvXRt3Xvva1qLvzzjujbseOHVGXqquri7oxY8ZE3Wc+85moS+8/073B/Pnzo+7GG2+Muoceeijq0j1iZ2dn1Llf3HP169cv6o466qioS8+Euru7o+6uu+6KunTPlN5PNDc3R126B/vCF74QdcOGDYu69L7yF7/4RdStX78+6uyt2BXpnmnixIlR993vfjfq0nUo9dJLL0Xd17/+9ah79NFHoy5dJ5PrMv0cT6/x9N82XUsPP/zwqPvwhz8cdem5+RNPPBF1Dz/8cNSl/2b0Len7ecKECVE3fPjwqLv99tujrq9/RqfrS3rOdM8990Rdujc9/fTTo+68886LuiuvvDLq0vtFSKVnJKn02k0/29K1NP2MTs/Upk+fHnXpfjM921q+fHnULVy4MOo2bdoUddaW3ZO/RAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRafW8/Af67SqUSdTt27Ii6OXPmRN2UKVOi7ogjjoi6U089NepOPPHEqNuyZUvUvfLKK1G3evXqqOvu7o66+vrqXkrp+wBSDQ0NUTd16tSoe+973xt1b3/726Nu8uTJUTdkyJCoS3/fVLoWtLe3R93mzZujbuDAgVE3atSoqCuVSlHX09MTdePGjYu6CRMmRF1nZ2fUpf8eGzZsiLrt27dHXblcjjp2T8lnb3rt3nvvvVG33377Rd1hhx0WdXV1dVGXvuf/6Z/+KeoefvjhqHMN0ZvSvcFpp50Wdccff3zUdXR0RN0///M/R93dd98ddemeJN0bNDY2Rt3EiROj7tvf/nbUHXfccVHX1dUVdQsWLIi6W265Jermzp0bdevWrYu6dC/kfnHPlV6T/fv3j7qjjjoq6tIzjfQ+YebMmVF3ySWXRF1qr732irr9998/6tLfI70m//jHP0bdk08+GXXpZ4w1g5qafH0ZOXJk1H3pS1+KunTPlD6/JUuWRN23vvWtqHvssceirtrXW23tzv9ve/pY1d7Ppef/3/nOd6IuXZvT/dIPf/jDqFuxYkXUWSN3T+n7ftKkSVX9udX+jO4t6fs+PcdJz2BvuummqDvhhBOi7uyzz466X/3qV1G3devWqINUuhZUe5/R0tISdQMGDIi68ePHR93HP/7xqDv99NOjbtiwYVGXvi7pNX7bbbdFXbonWblyZdSl99u8NfwlKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNDqe/sJ8Ncpl8tR9+qrr0bdVVddFXWPP/541E2aNCnqBg4cGHXp7zF//vyomzlzZtSdcsopUVdXVxd13d3dUQepUqkUdWPHjo26z3/+81H3rne9K+qam5ujrrY2m+mtVCq90qXXeFNTU9QNHTo06tLXJe16enqiLn1+n/vc56LuYx/7WNQtX7486p5++umou++++6Luueeei7qtW7dGXfq+YvfT2dkZdYsWLarqzx08eHDUpfvDu+66K+rSa6i1tTXqoDeNGDEi6s4+++yoa2hoiLqFCxdG3SuvvBJ16XowaNCgqEs/82fPnh11n/jEJ6Jun332ibrt27dH3dy5c6MuXf+eeuqpqFuzZk3UpZ8f9hBU27p166Ju8+bNUZeuLemZy2GHHRZ16VlKV1dX1A0YMCDq6uuzY9OlS5dG3ZVXXhl1a9eujbr0/g5qavLzmUsuuSTqLrjggqhLz1PSz9Qf/OAHUZfuDdra2qKu2p/RyeOlZz3pmnbIIYdE3b/9279F3eTJk6Mu3c/98Ic/jLoHHngg6pzD79nSz+gZM2ZEXXqekp5dpo/X16VrX3q/8+yzz0bd888/H3X7779/1KX3n+kZsfs2Uu3t7VGX7oMmTJgQdSeccELUrVy5Muo++tGPRt2pp54adekanp45p3umYcOGRd2FF14Yden99o9//OOoS/elvDX8JSoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQ6nv7CfDm6uzsjLqlS5dG3erVq9/I0/mrdXR0RF25XI66+vrsrV9bm80ZViqVqEv/PSCVvkff9ra3Rd0pp5wSdYMGDYq61NatW6Pu5Zdfjrpt27ZFXV1dXdSNHz8+6vbaa6+o69+/f9SVSqWoS6VrVVNTU9Slr0vaTZkyJepmzJhR1Z/705/+NOqefvrpqEs/i9J/D94ayfU2YMCA6LEmT54cdY2NjVGXSt976WdH+njQm9LPyiFDhkTd8OHDo667uzvqWlpaou6cc86Juq6urqibMGFC1E2fPj3qxo4dG3XpurZly5aoe/TRR6Putttui7pFixZF3YYNG6Iu/ffwmU8qfa+0tbVF3X333Rd1PT09UXf44YdH3bhx46IuvR/bvHlz1KX7/6FDh0Zd+jpfccUVUffEE09EnbMjdkW6F5o1a1bUffzjH4+69Fwj/cz/0Y9+FHV33XVX1G3fvj3q0vUvfZ3TLtkzDRs2LHqs973vfVF38cUXR126j0zXqhtvvDHqfvnLX0ZdujazZ0vXoP322y/q0j3Ypk2boq5o0tcv/Q7gxRdfjLpDDjkk6gYPHhx1UG3pZ9b9998fdYcddljUzZ49O+qam5ujLr3W0mv8T3/6U9SlZz3pmf1FF10Uden3qaeffnrUXXPNNVFnj9O3+EtUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodX39hPgzVWpVKKuo6Ojql0qfX6pUqkUddu3b4+6+vrsEunp6Ym6zs7OqINUbW02Czt9+vSoGzJkSNSl19qmTZui7tprr426hx56KOoGDBgQdUcffXTUjR8/PurSNSNd+9K1JV3T1qxZE3WpxsbGqOvXr1/U1dXVVfXnjhs3Lur23nvvqHvuueeirlwuR10qvd6q/ZlaNMn778ADD4we65xzzom6dA3fvHlz1KXvgcMOOyzqJk+eHHXr16+Puu7u7qiDXZGukenavGLFiqgbM2ZM1KWfgSeddFLUNTc3R92IESOiLv1MbW1tjbrFixdH3e9///uoe/rpp6Nu0aJFUZeuV21tbVGX7tWg2tKzmeeffz7qli1bFnXXX3991KV7nHRtTvf1V1xxRdSlz+/FF1+MujvvvDPq0rUUdkX6Wf6+970v6kaPHh116RnnLbfcEnXp+rJ27dqoS6XnEOl5z8CBA6PukEMO2WnzqU99Knqs2bNnR11TU1PUbdiwIeouu+yyqPvpT38addu2bYs69mzp/V16X9TS0hJ16ZrW1dUVdbwx6Wdb+n5J987OYKm29H7n5ptvjroPfOADUZeeWaV7g40bN0bd/fffH3VXXnll1KX7vvTsbeLEiVH3tre9LeoGDRoUden+0BrUt/hLVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHV9/YToG+oVCq9/RTeUgMGDIi6+vrsEmltbY269HUu2r8Hf730vdLY2FjVx+vp6Ym62tpsVvfII4+MuoMPPjjqRo0aFXVjx46NusGDB0ddXV1d1JXL5ahbsWJF1F1//fVR96c//Snq0uc3aNCgqJsyZUrU7bvvvlGXvq+WLl0adc8991zUdXV1RR27p+T9fPbZZ0ePtc8++0TdmjVrou7Xv/511J100klRN3369Kg788wzo+6pp56Kuu7u7qiDXZHuSdatWxd1t956a1Ufb/jw4VGXrhsDBw6MuvQzK72Puffee6Nuzpw5Ubdw4cKo27ZtW9Rt37496rZs2RJ1PvPp69K1L73Gq32mUSqVoq6hoSHqjj766KibPHly1HV0dETdf/zHf0Td66+/HnXpvxvsivSM85hjjom69H578eLFUXf11VdH3caNG6MufX7pnmnEiBFRd+CBB0bdGWecEXXvfOc7d9oMGTIkeqx0bVmwYEHUffvb3466hx56KOp27NgRdc7Dqamp/h4i/X4nPa9obm6OuvT3KJr+/ftH3YwZM6IuvW9L7wPt1ai29D21bNmyqEvPrC699NKoGzZsWNSl19BLL70UdZ2dnVGXrvXp94Hpfi7db6Z7nPTx6Fv8qwEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVW39tPAHpDc3Nz1NXWZnOGbW1tUdfe3h51kKpUKlH30EMPRd0FF1wQdRMmTIi6wYMHR92sWbOiLlUqlaIuvcZ7enqibtu2bVH37LPPRt0Pf/jDqPvzn/8cddu3b4+69H2Vvs5z586Nurq6uqgbNGhQ1KW/79atW6Ouu7s76uhb0ut88uTJO21OO+20qv7MX/3qV1H3i1/8IurSa+jAAw+MusMPPzzqWlpaoi7dB6VrEOyK9DP6vvvui7pXXnkl6t72trdF3SmnnBJ16Wfg888/H3X33HNP1N17771Rl77O6f1TuVyOunSvln6WW4fYU/TWezn9uQMHDoy6v//7v4+6pqamqEvvn+bMmRN1HR0dUQdvhgEDBkRdumdPP1PTz+hJkyZFXXoPNXz48KhL72VOOumkqJs+fXrUpWfOiTVr1kTdr3/966j75S9/GXWvvvpq1HV2dkYd7Ir0rDGVnkOMGDEi6oYMGRJ11T5z7uv3J+ke7IQTToi6gw46KOqefPLJqFu9enXUQW9J16qrr7466tLv29L90vjx46Pu3HPPjbrkHL6mJl9LDz300KhLf9/0zCo9U1u7dm3U0bf4S1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAECh1ff2E4BqKpVKUTd69Oioq63N5gy3bt0adZ2dnVEHqXK5HHXz5s2Luv/4j/+Iuk996lNRN27cuKirr6/ux1H6umzZsiXqFixYEHV//OMfo+62226LukWLFkVde3t71FUqlairtvT5pTZt2hR1vfX70rfU1dVF3aRJk3bapPuHdevWRV26FmzcuDHqli1bFnU9PT1RN3bs2Kjr169f1EFvSvcG27dvj7rVq1dH3eLFi6Nu4sSJUbdy5cqomzNnTtQtXLgw6tJ1Lb3fSdehVPqZX+0O+MvSs5Tjjjsu6qZPnx51O3bsiLrLLrss6tavXx91sDtIP8uHDRsWdcn9U01NTc2//uu/Rl16ptvY2Bh16T1K+njp3iA9I7777rt32lx11VXRY6VnVulzq/Y+DXZFeq2lZ7rp/c4BBxwQdeecc07UvfTSS1GXnnGm97Pp9Zuuuelaevjhh0fd1772tahL3wc//elPo661tTXqoLek1+7rr78edem19p3vfCfq0mv8+OOPr2qXrgXp65euBbfffnvU3XTTTVGXnjU6i+pb/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0Op7+wlANdXV1UXd+PHjo662NpszXLt2bdR1dXVFHVTb1q1bo+6Xv/xl1D3++ONRd+aZZ0bd/vvvH3WlUinqFi5cGHUPP/xw1L344otRt379+qjr7OyMup6enqgrmkql0ttP4S1VtN+32tLP8iFDhuy0aWhoiB6rra0t6tJ9y+jRo6PupJNOirrGxsaoS9cg71F2B+n7Od2vb968OeoWL14cddu3b4+6dA+xYsWKqEt/j/R1SdeDdE/XW+uLdQ3emObm5qi76KKLoq6pqSnq5s6dG3UPPvhg1HV3d0cd9Kb0vOf++++Pur322ivqBg0aFHUjR46MuvSzN+3a29ujbvny5VGXnh9dd911Uff000/vtEn/bcvlctTZ37A7SN+nra2tUXfTTTdF3cknnxx15557btSNGTMm6v7zP/8z6hYtWhR16f1iuja/5z3vibqzzjor6tI94mWXXRZ16WebM3b2FOnZzBNPPBF1l156adR94hOfiLp0LUjO4Wtq8v3ca6+9FnXpZ8Ktt94adStXrow695W7J3+JCgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLT63n4CUE11dXVRt++++1b157766qtR19XVVdWfC6lKpRJ127Zti7rHHnss6ubPnx919fXZx1FPT0/Updda+njp6wf0PaVSKepaW1ur0tTU1NQMHz486r785S9HXbpGzp49O+rSNe3xxx+Puh07dlT150JvKpfLUdfW1hZ1K1eujLqNGzdGXbqmpddlb92fWA9g95SuQVOmTIm6WbNmRV26Vl1//fVRt2nTpqiD3UH6mX/ZZZdF3bJly6LuxBNPjLqWlpaoS3+P9Az2oYceirpnn3026lasWBF16e+R7Dntlyii9H2f7g2efvrpqPvKV74Sdd/4xjei7uSTT466448/Puqqfe4ycODAqKutzf4Ox2uvvRZ13//+96Pu1ltvjbr0dYGiSdfIJUuWRN1Xv/rVqPs//+f/RF161p3+Ht3d3VHX3t5e1cdLv19k9+QvUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVW39tPAKqpf//+UTdhwoSoK5fLUbdy5cqogz1FpVKJus7Ozqp2ALuqq6sr6h566KGdNvfff3/0WCeddFJVu7q6uqhL1+YXX3wx6q699tqo27p1a9TBnqSnpyfq0j1Oulal0ucHsCv69esXdaeffnrUtfx/7dy/SmN5HMZhjsYUahjQwsvxBqwsxDvxKqwEm1yAdyCks9JCracQtIhiEKxE4p/Es91Wu8zLTjTufJ+nfsnJDJxM8uMz58ePaHd7exvtzs/Po1161gP/B+m/+dfX19Hu8PAw2vX7/Wi3tLQU7dI/R/qdaTKZzPS66W8t4Guk9+54PI52g8Eg2l1cXES7nZ2daLe1tRXtNjY2ol36WfXz589ol/69HB8fR7vhcBjt0s9w4Pekv4vS3cvLy++8HfhWPIkKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABKE1EBAAAAAAAAAACliagAAAAAAAAAAIDSRFQAAAAAAAAAAEBpIioAAAAAAAAAAKA0ERUAAAAAAAAAAFCaiAoAAAAAAAAAACitM+83AImmaaLd6upqtOv1etHu/f092j0+PkY7AOBrTafTaDccDn+52dvbi15rd3c32m1vb0e7tm2j3dnZWbTr9/vR7ubmJtql35egovT+TXcAnyE9c1lfX492m5ub0S797Ds9PY12zmbg36X322QymeluPB5HO4DPkH72pecao9Eo2h0cHMx0l35XS3epj4+PaOf3LAB/Gk+iAgAAAAAAAAAAShNRAQAAAAAAAAAApYmoAAAAAAAAAACA0kRUAAAAAAAAAABAaSIqAAAAAAAAAACgNBEVAAAAAAAAAABQmogKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABK68z7DUBiYSHr/Xq9XrTrdrvR7uHhIdrd399Hu6Zpoh0A8LWm0+kvN3d3d9Fr7e/vz3QHAPCZ0rOKtbW1aLe8vBzt0rOUk5OTaPf8/Bzt2raNdgAA/8Wsv2v47gIAX8uTqAAAAAAAAAAAgNJEVAAAAAAAAAAAQGkiKgAAAAAAAAAAoDQRFQAAAAAAAAAAUJqICgAAAAAAAAAAKE1EBQAAAAAAAAAAlCaiAgAAAAAAAAAAShNRAQAAAAAAAAAApYmoAAAAAAAAAACA0jrzfgOQaNs22r2+vka7y8vLaNfpZLfI1dVVtJtMJtEOAAAA4DsZjUbR7ujoKNqlZySDwSDajcfjaJeeMQEAAAD1eBIVAAAAAAAAAABQmogKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABKE1EBAAAAAAAAAACliagAAAAAAAAAAIDSRFQAAAAAAAAAAEBpIioAAAAAAAAAAKA0ERUAAAAAAAAAAFBa07ZtO5cLN808LssfrtvtRruVlZVot7i4GO2enp6i3dvbW7Sb020JAAAA8I8WFrL/i5mepaRnH9PpdKavBwAAAHx/8/qd70lUAAAAAAAAAABAaSIqAAAAAAAAAACgNBEVAAAAAAAAAABQmogKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABKE1EBAAAAAAAAAACliagAAAAAAAAAAIDSRFQAAAAAAAAAAEBpTdu27Vwu3DTzuCwAAAAAAAAAAPBNzSll8iQqAAAAAAAAAACgNhEVAAAAAAAAAABQmogKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABKE1EBAAAAAAAAAACliagAAAAAAAAAAIDSRFQAAAAAAAAAAEBpIioAAAAAAAAAAKC0zrwu3LbtvC4NAAAAAAAAAADwN0+iAgAAAAAAAAAAShNRAQAAAAAAAAAApYmoAAAAAAAAAACA0kRUAAAAAAAAAABAaSIqAAAAAAAAAACgNBEVAAAAAAAAAABQmogKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABKE1EBAAAAAAAAAACliagAAAAAAAAAAIDSRFQAAAAAAAAAAEBpIioAAAAAAAAAAKA0ERUAAAAAAAAAAFCaiAoAAAAAAAAAAChNRAUAAAAAAAAAAJQmogIAAAAAAAAAAEoTUQEAAAAAAAAAAKWJqAAAAAAAAAAAgNJEVAAAAAAAAAAAQGkiKgAAAAAAAAAAoDQRFQAAAAAAAAAAUJqICgAAAAAAAAAAKE1EBQAAAAAAAAAAlCaiAgAAAAAAAAAAShNRAQAAAAAAAAAApYmoAAAAAAAAAACA0kRUAAAAAAAAAABAaSIqAAAAAAAAAACgtL8A/cAU9x3zYNgAAAAASUVORK5CYII=\n"
-          },
-          "metadata": {}
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Visualize Generation"
-      ],
-      "metadata": {
-        "id": "8--XrDgpM-gV"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "print(\"=\"*60)\n",
-        "print(\"Visualizing Random Generation from Latent Space\")\n",
-        "print(\"=\"*60)\n",
-        "\n",
-        "vae.eval()\n",
-        "with torch.no_grad():\n",
-        "    n_samples = 16\n",
-        "    z = torch.randn(n_samples, latent_dim).to(device)\n",
-        "\n",
-        "    generated = vae.decode(z)\n",
-        "    generated_np = generated.cpu().numpy()\n",
-        "\n",
-        "    plot_results(generated, nrow=8)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 320
-        },
-        "id": "yZDuAQMEKG56",
-        "outputId": "b74b06ed-59cd-4d36-c870-ffaf5d87a006"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "============================================================\n",
-            "Visualizing Random Generation from Latent Space\n",
-            "============================================================\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 3000x900 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAACVEAAAKICAYAAABzbCh9AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAuIwAALiMBeKU/dgAAaKJJREFUeJzs/HmYnXWd5//Xqb0qlVQq+x6SEJIQ1oQdlEUECZvgbkOP+zQ92ratjmNfM+20rd3a43hpO5ft6LSog0ujDLa2IoqIEhAIEgiQhIQQsu9JpSq1L+f372++TU+9bA6pJPfj8ffzuuuk6tyf+3Pf551TKpfL5SoAAAAAAAAAAICCqh7tFwAAAAAAAAAAADCaDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodWO1g8ulUqj9aMBAAAAAAAAAIBjULlcHpWf65uoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqsd7RcAUEmlUinqyuXyK/xKgKKyDgEA8EpK95tFc6zvr4v2dzvW/x4p93cAAADF4puoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQiuVy+XyqPzgUmk0fiwAAAAAMMqO9WeDlX591dXZ/2VNH9UODw+/nJfzb/65AAAAcDSM1n2qb6ICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKrXa0XwAUSalUirra2uzUrK+vH7Epl8vRsfr7+6NuaGgo6tKfCwAAAFRe+gyi0qqrs/+zmXbJs4+qqqqqhoaGqJs4cWLUzZ07N+qmT58edYcPH466TZs2Rd327dujrru7O+oq/bzHcyEAAACOR76JCgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLTa0X4BcCwrlUpRV12dzSM2NTVF3dy5c6Nu6dKlIzYvvPBCdKznnnsu6rq6uqKuXC5HHXDsSde+5ubmqGtra4u63t7eqDt8+HDUDQwMRB0A8P+W7g1S7hXg6Kj0uZauBWlXV1cXdRMnToy6M844I+pe//rXR91ZZ50Vdelzkp/97GdRt3PnzqhLn0WNlvR94JoAwGir9OdA9fX1L+fl/AuDg4NRNzQ0FHXDw8Mv5+UAwAnv2L7bBgAAAAAAAAAAeIUZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHVjvYLgEoqlUoV7aqrsznDhoaGqJs/f37U3XTTTVE3d+7cEZsf/OAH0bE2bNgQdcDxq7Y2u+xPmzYt6lasWBF1F1xwQdStWrUq6n72s59F3c6dO6Ouv78/6srlctQBwCulpqYm6saNGxd1l1xySdRdeeWVUZe+vh/96EdRl+4NOjo6om5oaCjqgJcnXQtaWlqibs6cOVF34YUXRt0ZZ5wRden907Zt26JuzZo1FT1ed3d31A0PD0cdAIy29HOb9Bo9YcKEqEvvi974xjdG3bJly6Kurq4u6o4cORJ1P/7xj6Pu7/7u76Ju//79Uec+C45Plf6sPO3S+5NKfx6Tvr7095L+O6yRxyffRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRa7Wi/AEhUV2fzfqVSKerq6uqirqmpKepmzpwZdbfcckvUXXTRRVH33HPPjdjs2bMnOtbg4GDUAcee+vr6qJs9e3bUve9974u666+/PuoGBgaibuPGjVGXqvS1o1wuv5yXA68472U4ftXU1ERdW1tb1F1++eVR9/73vz/qFi9eHHUdHR1Rt2nTpqhL9wadnZ1RxyvPtYiqqnxNa2lpibqlS5dG3VlnnRV16XOS1atXR93KlSuj7umnn466Q4cORV16n+V843iQrhvps9oJEyZE3bx586Ju+vTpUZfu1caMGTNik+5vDhw4EHXPP/981O3evTvq0n1fX19f1A0PD0edNe34lD6jSz+3mTJlStS94Q1viLp3vOMdUTdx4sSo27lzZ9Rt27Yt6saPHx916Z5p2bJlUferX/0q6oaGhqIOODrS+/J033LFFVdE3YwZM6Iuvc/avn171I0bNy7qzj777KhL19xf//rXUbd27dqoS/dMHB2+iQoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACi02tF+ARRbqVSKuvr6+qhraWmJuhkzZkTd8uXLo+6iiy6KunPOOSfqOjo6om7VqlUjNtu3b4+O1d/fH3XlcjnqgJevtja7TC9YsCDqPvCBD0TdTTfdFHXp63v88cejbuXKlVHX3t4edcPDw1GXXotS6fGsp8eW6uqR/29Bc3NzdKxJkyZF3ZIlS6Ju6dKlUTdnzpyo6+vri7pHH3006h555JGo27dvX9QNDAxEXXqOw2hK1paqqqqqurq6qJs8eXLUnX/++VHX1tYWdel52dvbG3WNjY1Rl96jWA/g6EjXtPQZTroGnXzyyVGXrlU//elPoy7dC6XPXTo7O6Mu/Xe4n+B4kO5x5s6dG3U33nhj1L3xjW+MupkzZ0ZdQ0ND1KXPSZLnBun+Jr2/S9eqhx56KOoeeOCBqFu7dm3U7d69O+rSf+/Q0FDU2UceHekeIn3usnDhwqh71ateFXXptfdv/uZvou773/9+1KX3T9OnT4+6t73tbVGXPktO90LpvwM4OtJnLldeeWXUfeQjH4m6dA1P78fuvPPOqFu0aFHU/emf/mnUpZ/vpHuIzZs3R53P6Y8tvokKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAotNrRfgEUW11dXdTNmDEj6i666KKou/TSS6PurLPOirqWlpao27dvX9Tdf//9UffrX/96xObgwYPRsYaGhqKuXC5HHRRRqVSKusbGxqhbvHhx1P3FX/xF1F1yySVRV1ubbQ/Wr18fdd/4xjei7rnnnou6np6eqBseHo4669rxqaamJura2tqi7pxzzhmxufbaa6NjXX755VE3ceLEqEvXjHQNSq/5b33rW6Nu9erVUffnf/7nUbdp06aoS9cCeCWk51sqXdPGjx8fden6snfv3qjr6OiIuv7+/qjbvXt31PX19UWdazm8PJVe09K9S/oMJ30288wzz0TdAw88EHV79uyJuu7u7qgbHByMOmsax4N07zJnzpyoS+8VVqxYEXVNTU1Rl95TpOd5b29v1CXnebqvSjU0NETdFVdcEXVz586NupUrV0Zd+jx8+/btUdfZ2Rl1AwMDUWdtfmmV3kOkx5s+fXrUTZo0Kep+9rOfRd13vvOdqEvvn9L31ZYtW6IufbaaPivzvodjS7r/Wrp0adTddtttUbdo0aKoa29vj7oXX3wx6tLP3tPP/NN9abo/TP8e1tLjk2+iAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACq12tF8AJ6aampqomzBhQtRdeumlUXfDDTdU9OcePnw46p566qmoe+SRR6LugQceiLqtW7eO2AwMDETHAv51pVIp6lpaWqLuyiuvjLo/+qM/irply5ZFXXV1Njv97LPPRt3tt98edQ8++GDUpWvu8PBwRbtKK5fLo/JzTxS1tdn2dPbs2VH3vve9L+puuummEZtJkyZFx0qvvdu2bYu6jRs3Rt2uXbuibsqUKVF3zjnnVLS79dZbo+5v//Zvo66vry/qRmstgN9HXV1d1KV7jVR3d3fUpa8vXf/S9erIkSNR59p77PC3OLGlz3oWLlwYdW95y1uiLr2W/9M//VPUpXswew2KKH3+0dzcHHXXX3991L3mNa+JuvR+MX1We+edd0Zdek+2f//+qEvWjXRf1draGnXp7/jaa6+NuhkzZlS0S/e56XsgfQaWvuftcV5a+nupdDd16tSoGzNmTNS9+OKLUdfb2xt1ld4bDA0NVfTn7tmzJ+p8tgTHlrFjx0Zd+gw2/VypoaEh6vbu3Rt1v/vd76Ju7ty5UXfZZZdFXVNTU9Sln1Nt3rw56np6eqLOXuPY4puoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqsd7RfA8aVUKkVdQ0ND1J1yyilR99rXvjbqZs+eHXUbNmyIupUrV0bdE088EXXbt2+Pur1790Zdf39/1AEvT2tra9S98Y1vjLqPf/zjFf25AwMDUff8889H3Q9+8IOoe/jhh6Ouvb096oaGhqJueHg46srlckU7Xp50DzFmzJiou+SSSyraHTlyZMRm1apV0bH+z//5P1H37LPPRl16DvX19UVdc3Nz1L3pTW+Kuo985CNRt2zZsqhra2uLusOHD0ddumbAKyFd+2prs1vz9PxNr20tLS1Rl56X27Zti7r0fmdwcDDqgKNj3LhxUXfjjTdG3dSpU6Puhz/8YdQ9/fTTUZc+S7GHoIjSvcuECROiLr0fa2xsjLqNGzdG3X/+z/856tasWRN1vb29UVfJdSPdH06aNCnq6urqoi69Jz906FDUHThwIOrS+7v0b5E+Y/JM6Oio9O853ZPU19dHXfo+rfT9Sbrm1tTURF16fozWv8P5Bi8tveafffbZUff6178+6tJnTOn904MPPhh1qbe+9a1RN3PmzIr+3BdeeCHq0s/b0j0JxxbfRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRa7Wi/AI4vpVIp6saNGxd15513XtTNmjUr6rZu3Rp1P/jBD6Ju1apVUdfR0RF1PT09UTcwMBB1wMuTrlXXX3991P31X/911LW0tETdvn37ou7ZZ5+NunRNS4+3f//+qBsaGoq64eHhqCuXyxXtOLak74MdO3ZE3V133RV169atG7FZs2ZNdKyDBw9GXaWv9+k+LT03+vv7o666Ovt/GenPrampiTo4kVT6PKqtzW71071Qa2tr1KV7l7q6uqhzLYejo76+PuouvPDCqLv66qsr+nPXr18fdYODg1GX7pmAf11TU1PUpc8/+vr6oq69vT3qGhoaoi59falKri9tbW1Rd9NNN0XdVVddFXXp3+LRRx+Nuvvvvz/qtm3bFnVdXV1Rlz6Lst88OtLfc3oOpfcn6ecx6X1MKv13pPdF48ePj7p0bT5y5EjU2TPB0TF9+vSou/XWW6Nu6tSpUZee4+nnQA8//HDULVq0KOouuOCCqEvvK7u7u6Pu17/+ddSln0+kn3dwbPFNVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHVjvYL4NhQKpWirr6+PuoWLlwYdeedd17U7d+/P+r+8R//MeoeeuihqOvq6oq64eHhqEt/z2lXLpejDoqmoaEh6s4666yo+8QnPhF148aNi7p9+/ZF3d133x11u3btirpt27ZF3YEDB6Kuv78/6oaGhqIuXdOsfcen9O/W09MTdWvWrIm6tWvXRl1nZ+eITfra0n1BpVVXZ/8/YurUqVH3pje9KeoaGxuj7tlnn4269vb2qEvZV/FKqPT7Jb1W9vb2Rl2610jXq6ampqibNWtW1M2ZMyfq0rU+XZ+haNJrYGtra9SdfvrpUVdbmz1uTM/dpUuXRt3WrVuj7vnnn4+6dC3t7u6OutHaI8IrIX1u8NRTT0Xd/Pnzo27JkiVR95d/+ZdRt27duqh78cUXo66vry/qampqRmzSte/MM8+MusHBwai75557ou7OO++Mug0bNkRdus/17OjEll4r0/dz+r5K73fSPVO6B1uwYEHUXXzxxVGXrhubN2+OuhdeeKGix0vXSOcvJ4q6urqou+yyy6LuNa95TdSl92MDAwNR9+CDD0bdnj17ou7d73531E2YMCHqUjt27Ii6+++/P+rSGQJr2vHJN1EBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFVjvaL4BjQ01NTdRNnTo16m688caoa2xsjLqf//znUffYY49FXX9/f9Q1NTVFXVtbW9QNDg5G3ZEjR6Lu8OHDIzYDAwPRscrlctSlKn08qKqqqqqtzS5bS5YsibrPf/7zUTdz5syoS8/dr3/961G3devWqKuvr4+6PXv2RF1nZ2fU9fX1Rd3w8HDUWTeoqqqqGhoairpDhw5V9Ocm79PReo+WSqWoGzNmTNRdddVVUXfqqadG3b59+6LugQceiLr095yufen+K33vWdN4JaTv0wMHDkTdpk2bom7BggVRN2fOnKibMmVK1N16661Rt2rVqqjbtm1b1KXnORRNes367W9/G3XpuZauGePHj4+6N73pTVG3efPmqHvuueeibs2aNVG3ffv2qEvvs+w1eCWke93kmWRVVVXV9773vagbO3Zs1L3mNa+JuoULF0bd4sWLoy6Vrn/J+Zs+0z148GDUffe734269G+2c+fOqKvk74QTX/rst6OjI+oaGhqi7uabb466c889N+rStWXZsmVRl+6Fqquz781Iz8trrrkm6n74wx9G3be//e2o27t3b9Sl99FQaemz2gkTJkTdFVdcEXXp/VNq//79UXfXXXdFXbpWXXbZZVGXXhPS+6f77rsv6p5//vmoS/fN6fvFXujY4puoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqsd7RfAK6tUKkVda2tr1L361a+Oujlz5kTd9u3bK9rNmjUr6pYsWRJ1p59+etTNnz8/6mprs1Nuy5YtUXfPPfeM2GzcuDE6Vnd3d9QNDg5GXblcjjqoqsrPjVNOOSXq/vqv/zrqli5dGnUDAwNR95Of/CTqNm3aFHXpWnXgwIGo6+3tjbrOzs6oGx4ejjrrAb+P9P0yNDT0Cr+SV166T2tsbIy6M888M+re9a53RV1NTU3UPfLII1F36NChqBszZkzUpdeOdA3v6Oio6PGsfVRV5dfK9Bqd3hcdOXIk6vr6+qJu2rRpUbdw4cKoO/fcc6PuzW9+c9R97Wtfi7r29vaoc/5SNF1dXVH39NNPR91zzz0XdeleY/LkyVE3c+bMqDv11FOjbvHixVGXPgN78skno+6FF16Iut27d0edvQuvhPR9tXbt2qj77Gc/G3UrV66Mute97nVRl64H06dPj7rm5uaoS+5l6uvro2Pt2rUr6p555pmo279/f9Sl9+TWFn4f6fslfXaZPjd47WtfG3Xp85l0j5Pej23dujXq0s+VJkyYEHVTpkyJuttuuy3qLr744qj75Cc/GXVr1qyJuvQzLUhVV2ffUZPuHxYtWhR16dqSXqPT+470HFqxYkXUTZ06NepS6X3Rr371q6jr6el5OS/nX0g/A7BnOrb4JioAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQakf7BfBvUyqVoq65uTnqLrnkkqi7+eabo278+PFRNzQ0VNGfO3369KibNGlS1LW2tkZddXU2j5h2PT09UTdu3LgRm3/4h3+IjrVly5aoGxwcjDqoqsrXqpkzZ0bdbbfdFnWvetWroq5cLkfdo48+GnVPPvlk1J133nlRN23atKhLf881NTVRl0p/btqlfw94JSTv0/S9XFubbbHHjBkTdeeee27UfexjH4u62bNnR92uXbuibtOmTRX9uen+de/evVG3Y8eOqBseHo46axW/j/T9MjAwEHUHDx6MusOHD0dde3t7RY/30Y9+NOrmzZsXdX/wB38QdU8//XTU3XfffVGX/j3gRNHf3x916bmRPutJ18jt27dH3TPPPBN1a9asiboZM2ZE3Zlnnhl1V111VdSle87f/e53UffAAw9E3aFDh6Iu/ftyYkvP376+vqhL9+w//vGPo+7hhx+OuqlTp0bdKaecEnVnn3121C1cuHDEZvny5dGxZs2aFXXps6gHH3ww6uD3kV7b0s8e1q5dG3WPPfZY1C1ZsiTquru7oy7da/z0pz+Nuueffz7q0teXPrdKn+O8613virobb7wx6r7xjW9E3fvf//6oe+ihh6LOHodU+llvY2NjRbtKP7tsa2uLuvQz+quvvjrq6uvroy69Jqxfvz7qtm3bFnXp7zm9tnF88k1UAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodWO9gvg/1YqlaKuqakp6s4///yo++AHPxh1J510UtT19fVF3YQJE6KuoaEh6np7e6Nu3759UferX/0q6jo6OqIu/XssWbIk6qZMmTJiU1dXFx1raGgo6srlctRBVVVVVWNjY9Rdc801UfemN70p6mprs8vbCy+8EHXpWnD66adH3bnnnht16Vq6devWqBs7dmzUpb+/lHWD0ZTurZL3fbr/mjNnTtRddNFFUffOd74z6hYtWhR16dqybdu2qOvv74+6cePGRV17e3vU7d+/P+o6OzujbnBwMOqsabwShoeHK9ql7+eDBw9G3cqVK6NuxowZUfeBD3wg6qZPnx51b3jDG6Ju1apVUXfgwIGosx6QSvcj1dXZ/3VMu/TnVnptGa1zI92T7Ny5M+oOHToUdTU1NVGXrpEXXnhh1F177bVRlz6L+tznPhd16R4sfc4EVVX5+tLV1RV16Xpw+PDhqNuyZUvUpc+PWlpaRmw+/OEPR8dKn5XdcMMNUXfHHXdE3ZEjR6IOqqryvUFPT0/UPfXUU1GX3u9MmjQp6tJrYPqsNl2D0mtquqdLpZ97feITn4i69evXR91HP/rRqPtv/+2/Rd2b3/zmqEvXekjXtPTZwrp166Iufeacfi43c+bMqJs2bVrUjR8/PupS6Wf+u3btirrJkydH3d69e6Mu/fumz+IrvYbz8vgmKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNBqR/sFFEWpVIq6+vr6qFu8eHHUfeADH4i6U045Jeq6urqibtu2bVG3a9euqNu6dWvUPfjgg1H33HPPRV1PT0/UzZs3L+ouueSSqBscHIy6hx56aMQm/Vv09/dHXblcjjpObDU1NVG3YMGCqHvve98bda2trVHX3d0ddelasGjRoqi7/PLLoy79d+zbty/q0r9Huqb19vZGXbpWWTcYTen5MXny5BGb8847LzrW9ddfH3UXXnhh1E2aNCnq+vr6om7Dhg1R98QTT0Rdupbu3bs36vbs2VPRzh6HIkrfz+m1vKOjI+qS+5Oqqqqqa665JurSdTft5s+fH3Xt7e1Rl/7+OP6kz3Bqa7PHauPHj4+6GTNmVPTnHjhwIOrSa+rQ0FDUHeuqq7P/Uzpu3LioS++z7r333qhL16B3vvOdUXfZZZdFXfr6Vq5cGXUnyvuFY0u6x0nff+nzo/Rea3h4OOoOHTo0YvOd73wnOlZ6/zlr1qyoS+8/X3jhhahzn0VVVf4+GBgYiLp0j5NeU9NnR+k5nv470uON1nmUvr70fvHOO++MurPOOivqVqxYEXV/+Id/GHWf/exnoy59zsSJKz030vusu+++O+omTpwYdWeeeWbUNTc3R11LS0vUpWtpuqal+7S6urqoS/dC+/fvj7p0f5g+O0r3r/ZWR4dvogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAAqtdrRfQFFUV2fzalOmTIm6m2++OeoWLlwYdfv27Yu6++67L+p++9vfRt2mTZuibs+ePVHX2dkZdenf46STToq6P//zP4+6008/Pep+9rOfRd0Pf/jDEZvDhw9HxyqXy1HHia1UKkXduHHjou6mm26KutmzZ0ddanBwMOrSNXLy5MlRN378+KhLX9+hQ4eibsOGDVG3efPmqDty5EjUDQ8PRx28EtL1auzYsVF3+eWXj9i88Y1vjI61dOnSqGtsbIy6/fv3R116jqf7vvb29ooe78UXX4y6gwcPRl1/f3/U2ePAvy49P4aGhqIu3eOk60ZfX1/UpXu1BQsWRN3TTz8ddenvxTp0/EmfGaT3RWeeeWbUXXjhhVHX0NAQdatWrYq61atXR93evXujbrSu0enfrbW1NepmzJgRdelatWPHjqjbvXt31NXWZo91BwYGoq67uzvqrGm8EtL7u/Q8T9+n6d4lXddSNTU1IzZbt26NjtXV1RV1EydOjLqWlpaoS/9m8Puo9Lmb7te9n1+e9PecPuv+5je/GXWvec1rou7aa6+Nur//+7+PuvQ5HSeu9HORdH/9m9/8JurSfdC73vWuqFu+fHnUjRkzJurStTRdM9LP/NNrQvq5V3r/5NpxYvNNVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHVjvYLKIqampqomzp1atQtXbo06vr6+qLu/vvvj7rvf//7Ubd9+/ao6+7ujrr09zdlypSou+aaa6Lu3e9+d9TNnDkz6u65556o+/jHPx51+/btG7EZHh6OjgVVVVVVpVIp6tJzbfHixS/n5fwLg4ODUZeuGem529zcHHWpXbt2Rd13v/vdqEvXlm3btkXd0NBQ1JXL5aiDV0K6XtXV1UXdwMDAiM2BAweiY23atCnq0rVgz549UZf+ThYsWBB16dq3d+/eqDt48GDU9ff3R501CI496b1Huh6k94vjx4+PulNOOSXqamuzRyXWoRNX+rdN983Tp0+PurPOOivq0vuxzs7OqEv3JD09PVHX1dUVdenvOd3jjBkzJuqWLVsWdS0tLVHX0dERdSeddFLU/dEf/VHUNTU1Rd29994bdZs3b466ZN/M8Ss936qrs/+bnd6PpdfedK+R3lNU+vlH+vtLpPdjDQ0NUZf+zVL2QRwP0vdpen6ka1UqvaaeKOdbuoa/+OKLUbd79+6oS/fic+fOjbr9+/dHHaT7jPb29qh74oknou7MM8+MuvS+KN3fpGtVev/00EMPRd1PfvKTqHvyySejLr2PTu970881T5S1/kThm6gAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCqx3tF1AU5XI56oaGhqKupqYm6hobG6OupaUl6tra2qIu/XfMmjUr6i6++OKou+SSS6Ju3rx5Udfb2xt1/+N//I+o+7u/+7uo6+zsjLr0fQWp2trsstDU1BR1Bw4ciLrdu3dH3bhx46Kuvr4+6tK1b3h4OOra29uj7qtf/WrU3XXXXVG3Y8eOqBscHIw6OB6k18D0mvrUU0+N2AwMDETHSteqrq6uinbnnXde1E2dOjXqUunrS9cg+xs4eqqrs/9Xle79Ghoaoq67uzvqSqVS1KX3x2mX/l44caXXop6enqjbsGFD1O3cuTPqFi9eHHVvfvObo27GjBlRt2rVqqjbu3dv1KVrRmtra9SdccYZUZfuhdL748mTJ0fd3Llzo66uri7q7r333qj70pe+FHX79u2LuvT+mGNLek1Nr4Hjx4+PuvQZbPq+37NnT9Sl62n6DLvSkudW6f1d+rdI79t27doVde7bOJGka1+6J0n3OIcPH4669PxNr9Gjdf6mP/fIkSNRd+jQoahLP4dMPytIr6nWSdL3QPrMNH3OnX62ne6/Uum/49FHH426b3zjG1H35JNPRl26llb63HX/dHzyZBAAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACi02tF+AUUxNDQUdXv37o269evXR93SpUuj7nWve13UXXzxxVE3MDAQdVOnTo26pqamiv7chx56KOr+8i//Muo2bNgQdX19fVFXLpejDiqtujqbrT18+HDUPfDAA1HX1dUVdWeffXbUnXLKKVGXri3p67v77ruj7sc//nHU7dy5M+oGBwejDk4k6bWyt7c36rZs2TJik17HZ8yYEXW1tdlWPN1HDg8PR119fX3UlUqlqOvv74+69PUBL196/jY0NERdW1tb1M2aNSvqpk+fHnWtra1Rl66TR44ciTrrFek+I70Grl27NuruuOOOqBs3blzUXXDBBVH3hje8IepuvvnmqKv0OZTumdI1raamJurSZ0zpfnPbtm1R97/+1/+KuvS+8tChQ1GXrqWc2NJ7hZNPPjnqrrzyyqhL9y7pc6b9+/dHXXqeV/peK3m+9Sd/8ifRsdI18plnnom69FmU59ecSNK9Qfp51nnnnRd16TP21atXR92uXbuibrQ+p0p/z+lztQULFkRdT09P1HV0dEQdVFp6rqXd3Llzoy69f0qlz1x++ctfRt3TTz8ddZ2dnVHnWQ+/D99EBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFFrtaL+AohgeHo66vXv3Rt0//MM/vJyX8y+8+tWvjroZM2ZEXV9fX9Tt2LEj6p544omo+/a3vx11Tz31VNR1d3dH3dDQUNTBaCmVSlE3MDAQdbt27Yq6np6eqGtvb4+6dA065ZRToi59fb/4xS+i7vbbb4+6LVu2RF369wD+deVyOeqSvcuBAweiYzU3N0dda2tr1E2ePDnq5syZE3UNDQ1Rl/57+/v7ow44empqaqIuXa+WLVsWdVdffXXUpfefY8aMibr9+/dH3bZt26LO/R2pdJ9x5MiRqHvyySej7r/8l/8Sdeeff37UrVixIuqWLFkSdekep7Y2eyzZ1dVV0S5dM5599tmoe/zxx6PuwQcfjLp9+/ZFXXq/mL5Poaqqqqq6Ovs/1yeddFLUXXnllVGXXnvXrVsXdek9z+DgYNQ1NjZG3QUXXBB1n/rUp0ZsFixYEB3r8OHDUffFL34x6jo7O6MOTiTpNbW3tzfqZs+eHXXpfdE555wTdffff3/Ubd68OerS5z3pfeW8efOi7j3veU/UTZgwIerSZ/vp55UwWsaOHRt16RqU3o+l9xPpfUx635vuSdIZDI6O9PPoY/0+1TdRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhVY72i+A/9vAwEDUbdq0Keo+/elPR91Xv/rVqGtubo66jo6OqGtvb4+6vr6+qOvv74+64eHhqCuXy1EHx7r0vTw0NBR16Tl04MCBqNu6dWvU7dixI+r2798fdS+88ELU3XHHHVGXrs3pmgYcPck6ma6Rg4ODUdfS0hJ1J598ctQtXrw46tJ/x86dO6Mu/ffaV8Gxp76+PupmzJgRdcuWLYu6SZMmRV2653z22Wejbv369VGXrmuQSq+B6X3C9u3boy69lv/4xz+Ourq6uqirra3s48b095d26dqSPqNL14x0D2bPxCuh0s+F0vNj8uTJUdfW1hZ173jHOyp6vPRZ8hVXXBF1V155ZdQlry+9JnzlK1+Jut/85jdRZx9EEVX6Ocnjjz8edfPmzYu66667LupWrFgRdTU1NVHX29sbdel95dixY6Ouujr7/o81a9ZE3Ze//OWoSz+vtFej0kqlUtQ1NTVFXfrMJf256f3T7t27o+7gwYNRl67NHFtOlDXSN1EBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFVjvaL4B/m8HBwag7fPhw1HV0dERduVyOOuDElq4F6Vq1a9euqPvpT38adTt37oy6NWvWRN26deuiLl1Lh4eHow44ekql0ohNuval53hra2vUnXHGGVE3adKkqEvXtK1bt0bd0NBQ1AFHT7pedXd3R93atWujbvXq1VFXV1cXdS+++GLUffnLX466jRs3Rt3AwEDUwWhJ9xppl9639fb2Rh1w/EqvgU899VTUpc9drrzyyqi77LLLKtqlampqoi69N9q+ffuIzRe/+MXoWD/4wQ+iLv2cAPjXpfdPv/zlL6MufT5z3XXXRV26lp588slRN27cuKjr6+uLuvXr10fdypUro+6HP/xh1G3evDnq0j0xVFr6DCd5fl1VVVXV09MTdem+pb+/P+o2bNgQdQcOHIg6GE2+iQoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACi0UrlcLo/KDy6VRuPHAnAcq67OZn/r6uqibnBwMOqGhoaiDjh+JXvThoaG6FgzZsyIussvvzzqXv/610fdtGnTou573/te1H3nO9+Jun379kVduuYCx550D5Z2tbW1UTc8PBx16fqSHg8A+H+rr6+PulNPPTXqPvShD0Vdeg81bty4qEt1dHRE3X333Rd13/zmN0dsVq9eHR3ryJEjUWcfBMev9D4r/dw1XcNT6cfM6TP2dL1Kf671jxPFhAkTou6DH/xg1P3BH/xB1G3evDnq/v7v/z7q7r333qjr6uqKOk5sozTK5JuoAAAAAAAAAACAYjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQiuVy+XyqPzgUmk0fiwAAPyb1NbWRt2kSZOi7pJLLqlo19fXF3V33XVX1D377LNR19PTE3XDw8NRBwAAHNvSZ/vpPVRTU1NFj1dfXx91vb29UTcwMFDRbmhoqCINAMD/V2NjY9RNmzYt6tJnv+3t7VGXPsOGqqqqqlEaZfJNVAAAAAAAAAAAQLEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKGVyuVyeVR+cKk0Gj8WAABeUbW1tVHX0NBQ0W5gYCDqent7o25wcDDqRul2AgAAAAAAOEGN1mcPvokKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAotFK5XC6Pyg8ulUbjxwIAAAAAAAAA/w/p5/mjNG4AHGMqvWaM1trim6gAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBotaP9AgAAAAAAAACAY0e5XB7tlwAcR06UNcM3UQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVWO9ovAKCSSqVS1JXL5Vf4lQAAABRLpe/H3N8BAMeT6ursewuGh4ejzl4IGG2VXteAE9uJsnfxTVQAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChlcrlcnlUfnCpNBo/FgAAAAAAAAAAOEaN0iiTb6ICAAAAAAAAAACKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKrXa0XwAUSalUirrq6my+sVwuj9gMDw9HxwIAjq70el9TUxN1yb6gqirfG9hDAK+U9L6oqakp6hobG6Ouu7s76vr6+qIuXXcBAP7/Jfd4ra2t0bFaWlqibv/+/VHX09MTdfZBAACcqHwTFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGi1o/0C4EQwZsyYqFuwYEHUXXTRRVF35MiREZuVK1dGx9q+fXvUDQ4ORh0AnGhKpVLUNTU1Rd38+fOjbtGiRVGXXqPXrVsXdbt27Yq6np6eqBsaGoq6crkcdcCxp66uLuqWLl0adf/+3//7qEvXyfvvvz/q7rjjjqjbtm1b1KXrH/DSqquz/wOa7sHGjx8fde3t7VHX3d0ddfY4cPxK7wVramqibt68eSM2N998c3Ss9Dnyd77znaj753/+56jr6uqKOgCgMtL9SENDQ9RNnDgx6iZPnhx1zc3NUTc8PBx1Bw8ejLqdO3dGXaWfYXNi801UAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodWO9guA0VAqlaJuzJgxUXfjjTdG3S233BJ1p556atR1dHSM2MyYMSM61te+9rWoa29vj7pyuRx1APBKSq/51dUj/9+C1tbW6FiXX3551KX7gpNOOinq9u7dG3Xr1q2LuieffDLqVq9eHXVbt26Nuq6urqgbGBiIOnsS+Nela2RTU1PUnXHGGVH32c9+tqLHS9bwqqqqqkmTJkVdZ2dn1H3729+OukOHDkXd0NBQ1MGxLl1bGhsbo2758uVR95/+03+KurPOOivqnnrqqaj74Ac/GHWbNm2KOnsXOPbU1mYfo0ycODHqLrzwwhGbW2+9NTrWzJkzoy7dj6xcuTLqenp6om54eDjqeGnpNTW9dqTHGy2ugUARpWtzW1tb1K1YsSLq3vGOd0Rd+mymubk56tJ/b7rXWLt2bdR9/vOfj7oHHngg6g4fPhx1rm3HJ99EBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFFrtaL8AqKRSqRR1U6ZMibobb7wx6j7ykY9E3axZs6Iu/XdU8lh1dXUVPV65XI46ADgWNDU1jdicf/750bHe+973Rt2ZZ54ZdUNDQ1GXXqMbGxujbsGCBVF37rnnRt3KlSuj7ne/+13Ubd++Pep6e3ujbnh4OOrgeFBdnf1/qTFjxkTdihUrou7jH/941C1evDjqamuzRxaDg4NR19zcHHXTp0+PukmTJkVdV1dX1KXrlXstRku610i7hoaGqJs3b17ULVy4MOrSc/ess86Kuvnz50fdiy++GHXpmga8fOl6le6t0uerSdfW1hYdq76+PupS6f2n/QhVVd4HL1e6F2ptbY269H6iu7s76qwHcHTU1NRE3dy5c6PuhhtuiLrTTz896lpaWqIu3S+l0p+7fPnyqPvEJz4Rdf39/VH3q1/9Kup6enqijmOLb6ICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKrXa0XwAkqquzeb9JkyZF3W233RZ1f/zHfxx1bW1tUZfq6+uLuk2bNo3YrF69OjpWT09P1MHxIF0zRkupVBqVn1sulyvanSiK9u89UaTnUV1dXdTNnz9/xObf/bt/Fx1r2bJlUZfavHlz1G3cuDHqWlpaom7atGlRt2DBgqi7/PLLo+7JJ5+Mum9961tR98gjj0RdZ2dn1A0NDUUdvBLStS89z9/61rdG3X/8j/8x6ubMmRN1NTU1UTc8PBx16b3M3r17o66/vz/qJkyYEHW7du2KuoGBgagbHByMOqi0dN+crlVp19raGnVjx46NunQNqnQHHL/SPUlXV1fUNTQ0jNjU19dHx0rX5q1bt0Zdd3d3RX8uxxZ/t6MjPX/POOOMqHvzm98cdTt27Ii6+++/P+qSz5+qqvLPs1KNjY1Rl+7B0vvF9H7MecRoST/36u3tjbqdO3dGXfosNH320dHREXUzZ86MunQtTZ7/V1VVVb373e+OumeeeSbqtm/fHnXpfpOj49j+lBkAAAAAAAAAAOAVZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFVjvaL4BiK5VKUTdjxoyoe//73x91t912W9S1tLREXblcjrre3t6o27RpU9T90z/9U8WONTg4GHVQVVVVVVNTE3UNDQ1RV19fH3UTJ06MukmTJkVdU1NT1LW1tUVdbW12Wa2rq4u65ubmih6vp6cn6g4dOhR1HR0dUbdr166o6+7ujrr+/v6oS/+9XV1dUWedPLake4ixY8dG3c033zxi86pXvSo6VroWrF69Ouq+8Y1vRN2BAweibvr06VG3ZMmSqFu+fHnULViwIOquuuqqqFu0aFHUpb+/7373u1F38ODBqBseHo46+H2ke5d3v/vdUfehD30o6tL7sXRtTu+fjhw5EnXPPfdc1K1fvz7q0nV88eLFUdfe3h51W7dujbp0z2QdYrSk5/jQ0FDUTZ48OerGjRsXdelald5P7N69O+rSfy9w9FR6vUqPN3PmzBGbdN83MDAQdS+88ELUpc+vOTrS9xRHR7qHSPcub3/726PuyiuvjLqf/vSnUZc+K0ufTafv0/Hjx0fd2WefHXXpM/FVq1ZF3Z49e6LOM2IqLb13f/HFF6PuRz/6UdSl58a2bdui7tlnn4269POnqVOnRt2nP/3pqLv00kujLn3Wkz4r27FjR9RxbPFNVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHVjvYL4MRUKpWi7uSTT466P/3TP426t7/97VHX0tISdeVyOeq6urqibtWqVVF39913R93vfve7EZvOzs7oWOm/lWNLeq5VV2czs83NzVF32mmnRd2VV14ZdRdeeGHUzZ07N+pqamqibnh4OOrS33P6cwcHB6NuYGAg6hobG6Outja77Kf/jvb29qjbsmVL1G3evDnqVq9eHXUbNmyIunXr1kVd+u/l6Kirq4u65cuXR92tt946YjNu3LjoWFu3bo2673//+1G3fv36qGtoaIi6dC3o6OiIuvQcOumkk6Luuuuui7oZM2ZE3Qc/+MGoS9f6r3/961F35MiRqIOqqnwP9oEPfCDq/uzP/izqJk6cGHXpXjLdW+3duzfqfvazn0XdfffdF3XpHmfMmDEV7SZNmhR1hw4dirre3t6oS/8eMFrq6+ujbvHixRU9XuqFF16Iup07d0ad5y5w4kv3BpdccsmITbqmHThwIOrS+7ahoaGogyJKn6ekz86vueaaqEv3/w8//HDUPffcc1GXPtdIn9GlnwfedNNNUbd79+6oe/zxx6MORkt6n5Cek7/97W+jLn3WvW/fvqhLP49On1Wkn3v19PREXfrsN3196ed8HJ98ExUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBotaP9Aji+lEqlqJs1a1bU3XbbbVF3yy23RF1LS0vUpQ4fPhx1P/rRj6Lu7rvvjrrt27dHXVdX14hNuVyOjpVK3wNpV+nXd6xLfy+1tdny3NTUFHXTp0+PuhtvvDHqbrrppqgbM2ZM1O3fvz/qHn300ajbvHlz1G3cuDHqdu3aFXUDAwNR19HREXXp+yV9H0ydOjXqZsyYEXXjx4+PukmTJkVdf39/1KWSNbKqqqqqp6enoj+Xl6e6OpvxnzZtWtR96EMfqtjxjhw5Eh3rvvvui7r29vaoS8/JSq+56RrZ2dkZdUNDQ1F31113Rd0HPvCBqLvhhhui7s/+7M+ibsOGDVH3i1/8IurS3wvHp/r6+qh717veFXUf/ehHo66trS3q0r3G8PBw1KV7pi996UtR973vfS/quru7oy5dT08++eSoO+2006LuggsuiLre3t6oS68f6fpStHsyjh3p/cRJJ50Udek+Mj03Hn/88ahL7++AE9/s2bOjbs6cORX7mZs2bYq6nTt3Rl2674MiSp+7pJ9npfdt6edKld67pPcJY8eOjbqzzz476pYvXx51P/nJT6IufUZs/WO0pOda+vlTpZ8Z1NXVRV36DCz9POvcc8+NumXLlkVdauvWrVG3Z8+eqLO2HJ98ExUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBotaP9Ajg21NTURN38+fOj7mMf+1jUveUtb4m65ubmqEsdPnw46r7xjW9E3Z133hl1+/fvj7rh4eGoGxwcHLHp7++PjlUul6OOo6OxsTHqFi9eHHV//Md/HHVnnXVW1B06dCjqPvOZz0Tdb3/726jr6emJuoGBgagbGhqKuvScTLvRUl2dzU6nXV1dXdQ1NDREXX19fdSlf9+urq6oS9dJjo70ffC2t70t6i666KKoK5VKIzYbNmyIjrVp06aoa21tjbo5c+ZU9Odu27Yt6vbu3Rt16dqcrrnpNebzn/981M2bNy/qzjzzzKh7//vfH3WPPfZY1B08eDDqOLbU1ma30un9zic+8Ymoa2tri7pkTauqyvcuO3fujLr0vPzWt74Vdel9W/rvTe6fqqqqqqZMmRJ16d9jzJgxUZfuSbZs2RJ1fX19UedekNEyefLkqJs+fXrUpWtBundZtWpV1KX3J8DxK33+cfHFF0fdhAkTRmzS6/NDDz0UdelzafsCiij9fGzBggVRd+GFF0Zde3t71N19991Rlz5PSe8D099Luqe75pproi69z3rkkUeiLn1GfKw/24f0fid9vj5x4sSomz17dtTNnDkz6tK19LLLLou69BlOZ2dn1P3qV7+KunQNt7c6PvkmKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNBqR/sF8Mqqrs7m5JYsWRJ1H/vYx6LuxhtvjLrm5uaoSx06dCjq7rjjjqi76667oq69vT3qmpqaom5oaCjquru7R2xKpVJ0rPS9knblcrmiXdGk58aKFSui7tWvfnXUPffcc1H34Q9/OOqef/75qBsYGIi6lPfVS0vXlkp3fX19UVdpw8PDUef9cnSk16P58+dH3Tvf+c6oa2hoiLq9e/eO2DzwwAPRsdavXx916b5g48aNUbdly5ao6+joqGiXrgWVPtfSa8ynPvWpqPvKV74SdcuXL4+6Sy+9NOruvvvuqOPoSPe6F110UdR98pOfjLq2traoS9fS9Hw7cOBA1H3mM5+JuvQ+68iRI1GX/jvS30tNTU3UzZ49O+oWLVoUddOnT4+6uXPnRt0TTzwRden9cX9/f9RBKj3X5syZE3Wtra0v5+X8C+na9+yzz0ZduhcCjl8tLS1Rd/bZZ0ddcp+aPkt55plnom5wcDDqoIjS5zPXXHNN1I0dOzbqfvGLX0Td1q1bo67S90Xp2nf55ZdH3WmnnRZ16XO11atXR12lP3uASkvP3XStSp8tpJ8bvuY1r4m6U089NerGjx8fdY2NjVGX2rFjR9Sla5D7wBObb6ICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKrXa0XwD/NrW12Z/unHPOibq/+Iu/iLqLL7446pqbm6OuXC5H3ZEjR6Lu4Ycfjrr169dH3dSpU6Nuzpw5Udff3x91nZ2dUbd79+4Rm97e3uhYw8PDFe2GhoairmjS93ypVIq6mTNnRl1dXV3U/eY3v4m6nTt3Rp33wYktXQ/S93Olz4/0eBwd6d7l7W9/e9Sl6196Hfze9743YvPtb387OtaePXuirtLv+XSf0dfXF3WDg4NRN1rS1/fUU09F3apVq6Lummuuibobb7wx6n70ox9FnWvq0TFx4sSo++QnPxl16VpVXV3Z/9908ODBqPvKV74Sden6l963VXoPkf7+2traom7hwoVRN3/+/KibMmVK1E2aNCnqLr300qhL17+BgYGos7cile77li5dGnUNDQ1Rl75Ht23bFnUHDhyo6M8Fjj3pXiO9lp966qlRV1NTM2KT7quef/75qHM/QRGl9wljxoyJuiVLlkRder6l90XpGtTe3h516XOhk08+OepuvfXWqEs/o/jf//t/R93+/fujzl6NY116/zR58uSou+SSS6IufXZ59tlnR126lqb7r3SNTJ9pNDU1Rd348eOjLl3TfJ51fPJNVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHVjvYL4P9WV1cXdcuXL4+6z3zmM1F37rnnRl1DQ0PUpfr7+6Out7c36hYvXhx18+fPj7qBgYGo6+joiLpt27ZF3TPPPBN1v/nNb0Zs9u7dGx1raGgo6srlctSVSqWo46Wl50ZXV1fU9fX1Rd3SpUuj7tRTT426rVu3Rt2RI0eiLv29pF2l3/e8tEr//vw9jk8tLS1Rd9VVV0VddXX2fwGeeuqpqPv6178+YrNp06boWJVeW9J/a3q84eHhqDvWpf+O9FqZ7r9WrFgRdWeccUbUpX/f9H3FS6uvr4+69773vVF3zjnnRF1tbWVvubu7u6Pue9/7XtR98YtfjLrOzs6oS8/L9F4hPT/Sa8zZZ58dda961auibubMmVGX3kenzwPS9WXSpElRl/597cFIpWtfev9ZU1MTdem18vHHH4+6np6eqOPEll6zrJHHp3SPmO79Zs2a9XJezv9ly5YtUbdr166o8x6liCp937F79+6oO3DgQNS1tbVFXfq5V/o5Wnrf9o53vCPqTjnllKh7/vnno+7++++PuvQzADjWNTY2Rt3FF18cdW984xuj7rTTTou69PWl92Pp55XpOd7c3Bx1s2fPjrpXv/rVUffAAw9EnWcuxyffRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRa7Wi/gKKor6+PugsvvDDqPvWpT0XdsmXLoq6xsTHqUsPDw1FXU1MTdW1tbVE3YcKEqCuXyxXthoaGou6UU06JuokTJ0bdzp07R2z2798fHau7uzvqKv2746X19PRE3c9//vOomzlzZtSdfPLJUfeFL3wh6g4dOhR1Tz31VNQ98cQTUbd27dqoS86hqqqqqq6urqjr7++PulKpFHWVPo/StTnlPOf3sWDBgqhL16ve3t6ou+OOO6Juy5YtIzaDg4PRsSp9bqT7jKKp9O/58OHDFT1eQ0ND1NXV1UXdwMDAy3k5hTdv3ryoe8973hN1TU1NL+fl/Avp33fVqlVR99//+3+Puvb29qhL9xDV1dn/00rvjydNmhR1y5cvj7o3vOENUbdw4cKoS8/z9L43XQ9mz54ddenv78UXX4w6SLW0tERdujan90/pXm3Tpk1Rl96Xw+8jfT+n3Je/tPT33NraGnWvfvWro665uTnqknu83/72t9Gx0mdWUETpfUx6Ht17770VPV5tbfYRbXo/MXny5KhbsmRJ1N1www1Rl16L/vZv/zbq9u7dW9GfC6MlfUYybty4qDvttNOiLv2MOf08K/2cb926dVGXfh6Y7tPe8pa3RF36e04/x0ifbXF88k1UAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodWO9gs43tXU1ETdKaecEnUf//jHo27ZsmVR19jYGHWpcrlc0eOlv79KS/8dQ0NDUZf+O1pbW6PunHPOibqenp4Rm+3bt0fH2r9/f9T19vZGHS9PX19f1P3617+Ouh07dkTdJZdcEnXLly+PutNPPz3qrrrqqqhbsWJF1HV3d0fdiy++GHW/+MUvou6JJ56IugMHDkRd+j4YHByMuvT3kv7cdI2s9LWDY0upVIq6RYsWRV1DQ0PUHTp0KOqefPLJqOvv7x+x8V4+tqTvvfQ9NXfu3Ir+3M7Ozqjj5amtzW5p3/CGN0TdlClToi59H6TrxrZt26Lu05/+dNSl9wDDw8NRl/576+rqom7WrFlRd+WVV0bd1VdfHXVLly6Nuubm5qhLfy+Vlt6TpeuQ6xup9D0/e/bsqJsxY0ZFf256bqxevTrq0jUSXgnW5pcnfVY7c+bMqDvrrLOiLt2bJtfohx56KDrWwMBA1KUqvc+F0ZS+T48cORJ1jzzySNQ988wzUZfed6Sf86WfQ950001RN27cuKi75557ou6Xv/xl1CXP6GA0pdfKdF+Qfnacfm6zbt26qGtvb4+6Bx54IOrS5/Dpz02f4Vx//fVRN378+KhramqKuvTvy/HJN1EBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFVjvaL+B419DQEHVXXHFF1J155pkV/bmp4eHhinbV1dl83uDgYNT19vZGXWdnZ9S1t7dHXVdXV9RNnDgx6qZMmRJ1TU1NUXf66adXpKmqqqpau3Zt1JVKpagrl8tRx0tLz7X0PfrMM89E3fPPPx91d911V9RNmzYt6tJzKF0jzz///KibMWNG1L3vfe+LutTOnTuj7oUXXoi65557LurWrVsXdRs3boy6Q4cORV1/f3/Upe9768uxJb0uLFq0KOpqamqiLl3/uru7o45jR/qeqquri7qZM2dG3ete97qoS9+jGzZsiLqhoaGo46U1NjZG3Wtf+9qoq/R9Vnq/8/DDD0dd+r5Kz6Pa2uyRQPp7Ttf6FStWRF16Xs6ePTvqWltboy7996b3van0vjd9v+zatSvq7K2otPScbG5ujrr0Pbply5ao27FjR0V/Lie2Sj8H8756edK/x5gxY6LunHPOibpZs2ZFXSp57pI+O0ql+5b02QycSNL3ffr505EjR6Iufb6Q3sek91mnnXZa1O3fvz/q/uqv/irqDh8+HHWulYyWSj+TTD/3Su+f0s/v0s+B1qxZE3Xp/VNfX1/U1dfXR136+V1bW1vUpQ4ePBh16TMca9rxyTdRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhVY72i/gWFUqlaJu7NixUXfhhRdW9Hjp60uVy+WoGxoairru7u6o27x5c9Q9+OCDUff0009H3datW6NueHg46hYtWhR173nPe6JuwYIFUdfa2jpis3DhwuhY9fX1UZe+B9L3FEdH+nfr6uqKuvQc37dvX9RVV2czvQ8//HDUffvb3466adOmRd2ZZ54ZdaeffnrUzZkzJ+pOO+20qDvvvPOiLv27Pfvss1F3zz33RN3q1aujrrOzM+oGBgaiznp1dKTnb1tbW9TV1NREXboXGjNmTMV+brovKNp7qtL70vRvNn/+/Kj7r//1v0bdvHnzou7AgQNR981vfjPq0jWNl9bc3Bx16fuq0u/nwcHBqEv3YOn9YrpetbS0RF26F3rzm99c0eNNnDgx6tL3QaWvMam+vr6oW7lyZdR961vfirp0b1W06xb/do2NjVF39tlnR136HCJ9j6bPmHp6eqIOqqqskf+a9FpZ6a62Nvs446STToq6yy+/POrSPVh6zU+ebx08eDA6VqrSfwvnBkWUvu8rfX6ka9Af/uEfRl16X/TlL3856jZu3Bh16X0qjJZK7zMuvfTSqJsyZUrUrV27NurWrFkTdbt374669NlWuracccYZUfcnf/InUZc+E0r3aatWrYq6w4cPR5090/HJN1EBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFVjvaL+B4VyqVoq6uri7qhoeHK9ql0uMdOXIk6p555pmo+/73vx91K1eujLoDBw5E3cDAQNSNGTMm6lL79u2Luvnz50ddQ0PDiE1bW1t0rKGhoagrl8tRx4ktfR+k76u0S8/dvr6+qDt48GDUvfDCC1F37733Rl16Xs6dOzfqFi9eHHUXXHBB1M2bNy/qbrnllqibMmVK1D3yyCNRt2vXrqjr6emJuvT9x0tL14Pdu3dHXfr3mDBhQtQtWrQo6p5//vkRm66uruhYg4ODUVfp/Vz6t0j3rzU1NVHX1NQUdenf7LWvfW3U3XbbbVGXrpHp3+0HP/hB1D322GNRV+n3AS8t3RtUeq9bX18fddddd13UpWtaev85fvz4qGttbY26dI+T/l7Sdai6urL/Pyx9H3R3d0fdfffdF3Wf+tSnoi65ZlVV5esapJJnEFVVVVVLly6NuvQcT/eHmzdvjrr02pvumTwnObEV7e+bvu/Ta2+6J0l/7rhx46Lu/PPPr2iXrld79+6NujVr1ozY9Pb2Rseq9H6p0veVRTuH4PdRW5t9RPv6178+6ubMmRN1zz77bNR997vfjbr0fhtGS3oNTJ9dXn/99VF32WWXRd3hw4ejbt26dVGXnpPptTz9rPzSSy+Nuo997GNRt2TJkqhLrV+/PuruueeeqEs/K+D45JuoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqsd7RdwvBsYGIi6zZs3R93hw4ejrlQqRV2qs7Mz6p577rmo+/nPfx51q1evjrp9+/ZFXXd3d9RVV2fzg8PDw1E3duzYqKupqYm6Sv59e3t7oy59L5fL5ZfzcuBlqfTal+rv74+6oaGhqEvXqr1790bd2rVro+7xxx+PumuvvTbqLrrooqi7+uqro66joyPq0mtWX19f1KV/N15ael1Ys2ZN1PX09ETd+PHjo+7DH/5w1NXV1Y3YpOfQoUOHoi79t6ZrX7q/SX93ixYtirrly5dH3eWXXx51p512WtQ1NTVFXboX+uEPfxh1n/vc56LuyJEjUcfL09XVFXUPPvhg1J1++ulRV+n9//Tp06Nu2rRpUZeuzem6kUrXq0rv6dJ/7+DgYNTt2rUr6r761a9G3e233x51e/bsibr0PhUqLd1DzJw5M+rStSB9XpGeu+nanOwPq6rytaXSz1PS43mOQ1VVfs2vrc0+LhgzZkzUTZgwIerSvVW6V3vnO98ZdVOnTo269J5i5cqVUZc8Y0/P3fr6+qhLn33YZ8DLl+5x5s6dG3X/4T/8h6hLz/NPf/rTUbd79+6os9fgWJfug2bPnh11V1xxRdSdeuqpUZfOEKT7qnR/k65B6b/3lltuqejPTf9uO3fujLovfOELUZd+3pbeB3J88k1UAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodWO9gs4VpXL5ag7fPhw1N1+++0v5+X8C8uWLYu6+vr6qDt06FDUbdy4Meoef/zxqNu5c2fU9fb2Rl36d6upqYm6lpaWinY9PT0V7QYHB0dstm/fXrFjwWgbrXO3ujqbOW5qaqro8caMGRN13d3dUTc0NBR1W7dujbqTTjop6jo6OqKuoaEh6mprs+1Lek3g5Ul/z+ne4Je//GXU3XDDDVG3aNGiqPv85z8/YnPgwIHoWPv374+69HqfSs+hKVOmRF1ra2vUpWtfeu4ODw9H3b59+6LuK1/5StT9z//5P6Pu4MGDUWcNOjrS+4S77ror6s4+++yoe9WrXhV1jY2NUVcqlUalGy3p+ZGuB+le4xe/+EXUfeELX4i6J554Iur6+/ujDkZLen+S7iEmTZr0cl7Ov5CeQ9OnT4+6iRMnRl16/zQwMFDR46XPZ9LjpWtpujaP1jWm0q/vRNmrpf/e9HnKuHHjom7p0qVRd9lll0Xd4sWLo+6ss86KupkzZ0Zd6ne/+13U3X333VGXPK/t6+uLjpWe4+laf6zvI+F4kD6fee973xt1kydPjrr7778/6h544IGo85kRJ4p031dXVxd106ZNi7oJEyZEXXrtXbFiRdRdeumlUZc+A5szZ07Upc+IU3v37o26z3zmM1F3zz33RF1XV1fUcWLzTVQAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAECh1Y72CzjeDQ4ORt2GDRui7nOf+1zUzZs3L+qmTp0addXV2Tzd4cOHo2779u1R19HREXUDAwNRV2m9vb1Rt2XLlqhbs2ZN1E2aNCnq+vr6RmzWrl0bHSv9t5bL5aiDV0JNTU3UTZkyJerOOOOMqJs+fXrUpWtuqqenJ+rSNShdS9NrwtatW6Nu3759UXfgwIGo6+/vjzqOjvS6sH///qj75Cc/GXWlUinqXvva10bd2LFjR2xmzZoVHWv27NlRl/4bRkv6t033w+la8Mtf/jLqbr/99qh77LHHoi5dc+2Fji1DQ0NR9/TTT0fdX/3VX0Xd+973vqi7+OKLoy7d/zc2NkZdumdKDQ8PR116je7s7Iy6xx9/POruvPPOqPvJT34Sdel9avp7gWNduv9vaGiIunQNqvQ5tHDhwqi79NJLo27jxo1Rl96PHTx4MOrS30t6DUwd63tTjo50r7FkyZKou/rqq6Pu5JNPjrqWlpaoS59/pHvEL33pS1G3evXqqEv2Gul9VroWpF26BrkvoojSa+Wpp54adW9729uiLr1/+pu/+ZuKHg9OFOm1Ld2vd3d3R11dXV3UTZs2LerSfVV6f1dbW9kxkXTvsn79+qj7zGc+E3X33ntv1KUzDvY4VFX5JioAAAAAAAAAAKDgDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQakf7BRTF4OBg1O3bty/qDh48GHV1dXVRV12dzdMNDw9H3dDQUEW7crlc0a63tzfqOjs7o27//v1R197eHnXbtm2LuvHjx4/YrFu3LjpW+h6F0ZSuQQcOHIi65557LuoOHToUdR0dHVHX09MTdaVSKerSa0dNTU3UpWtfV1dX1HV3d0fdkSNHoi5d6zm2DAwMRN2WLVui7s///M+j7kc/+lHUXXfddSM2p512WnSsqVOnRl1tbbYVT9e+dH+TrmkbN26MukceeSTqHnzwwah78cUXoy7dV9njUFVVVdXf3x916fv5mWeeibpTTjkl6k4//fSoS9ehGTNmRF16X7lhw4aoS9fwTZs2RV16X5TuXdL7Tyia9JlQc3Nz1PX19UVdeo1Oz91x48ZF3aRJk6IuXdPS+7b0Pibd+1X6vqjSx0t/L6N1vBNF+ndLz6P0/n3v3r1Rl957pOtBund59NFHo+6b3/xm1D322GNRV8l7lErvWzxLgZcv3Wu8+93vjrqxY8dG3T/+4z9G3bPPPht16V4DThTpNXDnzp1R9/3vfz/qTjrppKibPHly1NXX10ddum9O91/pZ+Dpc/jbb7896tauXRt16f7VXojfh2+iAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACq1ULpfLo/KDS6XR+LEwqurq6qKura0t6lpbW0ds9u3bFx2rs7Mz6oaGhqIOXgnptSPtqquzWeKampqKHi9VW1tb0Z87ZsyYinYTJkyIunSrcfDgwair9Lo2PDwcdRyf0vOovr5+xKa5uTk6Vnq9T19bX19f1A0MDFT0eIODg1GX7g3Sc22Ubk/gFTFae5dKX9vS8zL9d6THsx7A0ZHuSWbPnh11t912W9S9+tWvjrqdO3dG3cqVKyvabd26NerS+450r5buwSq9Ro7WmlvpZ8Tp8dwHvrR0PRg3blzUzZs3L+oWLFgQdTt27Ii6zZs3R136HKK/vz/q7HHg+JQ++73gggui7mtf+1rUJc+iqqqqqm655ZaoW7VqVdT5jAdeWrqPHD9+fNRdd911UXfttddG3dy5c6Mu/fzkn//5n6Puvvvui7pdu3ZFXfps2n6dqqrR2zf7JioAAAAAAAAAAKDQDFEBAAAAAAAA/7927hhHcSAIw6g8EFhwTyJuwUm4AhfgSEgEgBG4N1ttNCqxjHrZ/724pPIkWNP+1AAA0URUAAAAAAAAAABANBEVAAAAAAAAAAAQTUQFAAAAAAAAAABEE1EBAAAAAAAAAADRRFQAAAAAAAAAAEA0ERUAAAAAAAAAABBNRAUAAAAAAAAAAEQbWmuty+Jh6LEW/itfX+/rIKs/BZ1+MoBvVN+pi8WiNDeOY2lutVqV5qqmaSrNXa/X0tz9fv+bxwEAAF5QPauo/h9TPYeY57k0BwDwp/V6XZrbbreluc1mU5o7HA6lud1uV5o7nU6lOd94APgUvd5ZbqICAAAAAAAAAACiiagAAAAAAAAAAIBoIioAAAAAAAAAACCaiAoAAAAAAAAAAIgmogIAAAAAAAAAAKKJqAAAAAAAAAAAgGgiKgAAAAAAAAAAIJqICgAAAAAAAAAAiCaiAgAAAAAAAAAAoi17PwDwunmeez8C8A9orZXmHo9Hae5yuZTmpmkqzVVV/47n8/nWvQAAwPs4qwAAPskwDKW56lno8Xgsze33+9Lc+XwuzVXPVgGA77mJCgAAAAAAAAAAiCaiAgAAAAAAAAAAoomoAAAAAAAAAACAaCIqAAAAAAAAAAAgmogKAAAAAAAAAACIJqICAAAAAAAAAACiiagAAAAAAAAAAIBoIioAAAAAAAAAACCaiAoAAAAAAAAAAIg2tNZal8XD0GMtAAAAAAAAQPl75TiOb917u91Kc50+4wJAd73egW6iAgAAAAAAAAAAoomoAAAAAAAAAACAaCIqAAAAAAAAAAAgmogKAAAAAAAAAACIJqICAAAAAAAAAACiiagAAAAAAAAAAIBoIioAAAAAAAAAACCaiAoAAAAAAAAAAIgmogIAAAAAAAAAAKINrbXWZfEw9FgLAAAAwA+onvV0OooCAAAA4EP0Oj9yExUAAAAAAAAAABBNRAUAAAAAAAAAAEQTUQEAAAAAAAAAANFEVAAAAAAAAAAAQDQRFQAAAAAAAAAAEE1EBQAAAAAAAAAARBNRAQAAAAAAAAAA0URUAAAAAAAAAABANBEVAAAAAAAAAAAQbdn7AQAAAAD4fK213o8AAAAAAC9zExUAAAAAAAAAABBNRAUAAAAAAAAAAEQTUQEAAAAAAAAAANFEVAAAAAAAAAAAQDQRFQAAAAAAAAAAEE1EBQAAAAAAAAAARBNRAQAAAAAAAAAA0URUAAAAAAAAAABANBEVAAAAAAAAAAAQbdlrcWut12oAAAAAAAAAAIDf3EQFAAAAAAAAAABEE1EBAAAAAAAAAADRRFQAAAAAAAAAAEA0ERUAAAAAAAAAABBNRAUAAAAAAAAAAEQTUQEAAAAAAAAAANFEVAAAAAAAAAAAQDQRFQAAAAAAAAAAEE1EBQAAAAAAAAAARBNRAQAAAAAAAAAA0URUAAAAAAAAAABANBEVAAAAAAAAAAAQTUQFAAAAAAAAAABEE1EBAAAAAAAAAADRRFQAAAAAAAAAAEA0ERUAAAAAAAAAABBNRAUAAAAAAAAAAEQTUQEAAAAAAAAAANFEVAAAAAAAAAAAQDQRFQAAAAAAAAAAEE1EBQAAAAAAAAAARBNRAQAAAAAAAAAA0URUAAAAAAAAAABANBEVAAAAAAAAAAAQTUQFAAAAAAAAAABEE1EBAAAAAAAAAADRRFQAAAAAAAAAAEA0ERUAAAAAAAAAABBNRAUAAAAAAAAAAET7BSUIkc3gq876AAAAAElFTkSuQmCC\n"
-          },
-          "metadata": {}
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "JfOlkPXKKKcU"
-      },
-      "execution_count": null,
-      "outputs": []
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using device: cuda\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "import torchvision\n",
+    "from torch.utils.data import DataLoader\n",
+    "from torchvision import datasets, transforms\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from sklearn.decomposition import PCA\n",
+    "from scipy.stats import wasserstein_distance, ks_2samp\n",
+    "from scipy import stats\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "torch.manual_seed(42)\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+    "print(f\"Using device: {device}\")\n",
+    "\n",
+    "def plot_results(images, nrow=10, title=None):\n",
+    "    images = (images.cpu().detach().clone() * 0.5 + 0.5).clamp(0, 1)\n",
+    "    grid = torchvision.utils.make_grid(images, nrow=nrow, padding=1, normalize=False)\n",
+    "    plt.figure(figsize=(10, (images.size(0) // nrow + 1) * 1.0), dpi=300)\n",
+    "    np_grid = grid.permute(1, 2, 0).numpy()\n",
+    "    plt.imshow(np_grid)\n",
+    "    plt.axis(\"off\")\n",
+    "    if title is not None:\n",
+    "        plt.title(title, fontsize=16)\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cqCmI6RyMPku"
+   },
+   "source": [
+    "## VAE Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "smIF9UF4ILGI"
+   },
+   "outputs": [],
+   "source": [
+    "class PreActResidualBlock(nn.Module):\n",
+    "    \"\"\"Pre-activation ResBlock: GN -> SiLU -> Conv -> GN -> SiLU -> Conv + shortcut.\"\"\"\n",
+    "    def __init__(self, in_channels, out_channels, groups=8, dropout=0.1):\n",
+    "        super().__init__()\n",
+    "        self.gn1 = nn.GroupNorm(groups, in_channels)\n",
+    "        self.act1 = nn.SiLU()\n",
+    "        self.conv1 = nn.Conv2d(in_channels, out_channels, 3, padding=1, bias=False)\n",
+    "\n",
+    "        self.gn2 = nn.GroupNorm(groups, out_channels)\n",
+    "        self.act2 = nn.SiLU()\n",
+    "        self.dropout = nn.Dropout2d(dropout) if dropout > 0 else nn.Identity()\n",
+    "        self.conv2 = nn.Conv2d(out_channels, out_channels, 3, padding=1, bias=False)\n",
+    "\n",
+    "        self.shortcut = (\n",
+    "            nn.Conv2d(in_channels, out_channels, 1, bias=False)\n",
+    "            if in_channels != out_channels else nn.Identity()\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        out = self.conv1(self.act1(self.gn1(x)))\n",
+    "        out = self.conv2(self.dropout(self.act2(self.gn2(out))))\n",
+    "        return out + self.shortcut(x)\n",
+    "\n",
+    "\n",
+    "class ConvVAE(nn.Module):\n",
+    "    def __init__(self, latent_dim=128, img_channels=1, groups=8, dropout=0.1,\n",
+    "                 out_activation=\"tanh\"):  # out_activation: \"tanh\" or \"sigmoid\"\n",
+    "        super().__init__()\n",
+    "        self.latent_dim = latent_dim\n",
+    "        self.img_channels = img_channels\n",
+    "        self.out_activation = out_activation\n",
+    "\n",
+    "        # ----------------\n",
+    "        # Encoder: 28 -> 14 -> 7 -> 4\n",
+    "        # ----------------\n",
+    "        self.enc = nn.Sequential(\n",
+    "            # 28 -> 14\n",
+    "            nn.Conv2d(img_channels, 32, 3, stride=2, padding=1, bias=False),\n",
+    "            PreActResidualBlock(32, 32, groups=groups, dropout=dropout),\n",
+    "\n",
+    "            # 14 -> 7\n",
+    "            nn.Conv2d(32, 64, 3, stride=2, padding=1, bias=False),\n",
+    "            PreActResidualBlock(64, 64, groups=groups, dropout=dropout),\n",
+    "\n",
+    "            # 7 -> 4\n",
+    "            nn.Conv2d(64, 128, 3, stride=2, padding=1, bias=False),\n",
+    "            PreActResidualBlock(128, 128, groups=groups, dropout=dropout),\n",
+    "        )\n",
+    "        self.mid = PreActResidualBlock(128, 128, groups=groups, dropout=dropout)\n",
+    "\n",
+    "        self.flatten_dim = 128 * 4 * 4\n",
+    "        self.fc_mu = nn.Linear(self.flatten_dim, latent_dim)\n",
+    "        self.fc_logvar = nn.Linear(self.flatten_dim, latent_dim)\n",
+    "\n",
+    "        # ----------------\n",
+    "        # Decoder: z -> 4x4 -> 7 -> 14 -> 28\n",
+    "        # ----------------\n",
+    "        self.fc_decode = nn.Linear(latent_dim, self.flatten_dim)\n",
+    "\n",
+    "        self.dec1 = nn.Sequential(\n",
+    "            # 4 -> 7  (k=3,s=2,p=1 gives 7)\n",
+    "            nn.ConvTranspose2d(128, 64, 3, stride=2, padding=1, output_padding=0, bias=False),\n",
+    "            nn.GroupNorm(groups, 64),\n",
+    "            nn.SiLU(),\n",
+    "            PreActResidualBlock(64, 64, groups=groups, dropout=dropout),\n",
+    "        )\n",
+    "        self.dec2 = nn.Sequential(\n",
+    "            # 7 -> 14\n",
+    "            nn.ConvTranspose2d(64, 32, 4, stride=2, padding=1, bias=False),\n",
+    "            nn.GroupNorm(groups, 32),\n",
+    "            nn.SiLU(),\n",
+    "            PreActResidualBlock(32, 32, groups=groups, dropout=dropout),\n",
+    "        )\n",
+    "        self.dec3 = nn.Sequential(\n",
+    "            # 14 -> 28\n",
+    "            nn.ConvTranspose2d(32, 32, 4, stride=2, padding=1, bias=False),\n",
+    "            nn.GroupNorm(groups, 32),\n",
+    "            nn.SiLU(),\n",
+    "        )\n",
+    "        self.out_conv = nn.Conv2d(32, img_channels, 3, padding=1)\n",
+    "\n",
+    "        self.apply(self._init_weights)\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def _init_weights(m):\n",
+    "        if isinstance(m, (nn.Conv2d, nn.ConvTranspose2d)):\n",
+    "            nn.init.kaiming_normal_(m.weight, nonlinearity='relu')\n",
+    "            if getattr(m, 'bias', None) is not None:\n",
+    "                nn.init.zeros_(m.bias)\n",
+    "        if isinstance(m, nn.Linear):\n",
+    "            nn.init.xavier_uniform_(m.weight)\n",
+    "            if m.bias is not None:\n",
+    "                nn.init.zeros_(m.bias)\n",
+    "\n",
+    "    def encode(self, x):\n",
+    "        h = self.enc(x)\n",
+    "        h = self.mid(h)\n",
+    "        h = h.view(h.size(0), -1)\n",
+    "        mu = self.fc_mu(h)\n",
+    "        logvar = self.fc_logvar(h)\n",
+    "        return mu, logvar\n",
+    "\n",
+    "    def reparameterize(self, mu, logvar):\n",
+    "        std = torch.exp(0.5 * logvar)\n",
+    "        eps = torch.randn_like(std)\n",
+    "        return mu + eps * std\n",
+    "\n",
+    "    def decode(self, z):\n",
+    "        h = self.fc_decode(z)\n",
+    "        h = h.view(h.size(0), 128, 4, 4)\n",
+    "        h = self.dec1(h)\n",
+    "        h = self.dec2(h)\n",
+    "        h = self.dec3(h)\n",
+    "        h = self.out_conv(h)\n",
+    "        if self.out_activation == \"sigmoid\":\n",
+    "            return torch.sigmoid(h)\n",
+    "        else:\n",
+    "            return torch.tanh(h)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        mu, logvar = self.encode(x)\n",
+    "        z = self.reparameterize(mu, logvar)\n",
+    "        recon = self.decode(z)\n",
+    "        return recon, mu, logvar\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mhEB8abtMvaZ"
+   },
+   "source": [
+    "## Loss Function & Training Script"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "O4anBk0VIOze"
+   },
+   "outputs": [],
+   "source": [
+    "def vae_loss_function(recon_x, x, mu, logvar, beta=1.0):\n",
+    "    recon_loss = F.mse_loss(recon_x, x, reduction='sum')\n",
+    "    kld = -0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp())\n",
+    "    return recon_loss + beta * kld, recon_loss, kld\n",
+    "\n",
+    "\n",
+    "def train_conv_vae(vae, train_loader, epochs=20, device='cuda', beta=1.0, lr=1e-3):\n",
+    "    vae = vae.to(device)\n",
+    "    optimizer = torch.optim.AdamW(vae.parameters(), lr=lr, weight_decay=1e-5)\n",
+    "    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)\n",
+    "\n",
+    "    print(\"Training Convolutional VAE...\")\n",
+    "    print(f\"Model parameters: {sum(p.numel() for p in vae.parameters()):,}\")\n",
+    "\n",
+    "    history = {\"loss\": [], \"recon\": [], \"kld\": []}\n",
+    "\n",
+    "    for epoch in range(epochs):\n",
+    "        vae.train()\n",
+    "        train_loss = 0\n",
+    "        train_recon = 0\n",
+    "        train_kld = 0\n",
+    "\n",
+    "        pbar = tqdm(train_loader, desc=f\"Epoch {epoch+1}/{epochs}\")\n",
+    "        for batch_idx, (data, _) in enumerate(pbar):\n",
+    "            data = data.to(device)\n",
+    "            optimizer.zero_grad()\n",
+    "\n",
+    "            recon_batch, mu, logvar = vae(data)\n",
+    "            loss, recon_loss, kld = vae_loss_function(recon_batch, data, mu, logvar, beta)\n",
+    "\n",
+    "            loss.backward()\n",
+    "            torch.nn.utils.clip_grad_norm_(vae.parameters(), max_norm=1.0)\n",
+    "            optimizer.step()\n",
+    "\n",
+    "            train_loss += loss.item()\n",
+    "            train_recon += recon_loss.item()\n",
+    "            train_kld += kld.item()\n",
+    "\n",
+    "            pbar.set_postfix({\n",
+    "                'loss': f'{loss.item()/len(data):.2f}',\n",
+    "                'recon': f'{recon_loss.item()/len(data):.2f}',\n",
+    "                'kld': f'{kld.item()/len(data):.2f}'\n",
+    "            })\n",
+    "\n",
+    "        n_samples = len(train_loader.dataset)\n",
+    "        avg_loss = train_loss / n_samples\n",
+    "        avg_recon = train_recon / n_samples\n",
+    "        avg_kld = train_kld / n_samples\n",
+    "\n",
+    "        scheduler.step()\n",
+    "        current_lr = optimizer.param_groups[0]['lr']\n",
+    "\n",
+    "        history['loss'].append(avg_loss)\n",
+    "        history['recon'].append(avg_recon)\n",
+    "        history['kld'].append(avg_kld)\n",
+    "\n",
+    "        print(f'Epoch {epoch+1}/{epochs}:')\n",
+    "        print(f'  Total Loss: {avg_loss:.4f}')\n",
+    "        print(f'  Recon Loss: {avg_recon:.4f}')\n",
+    "        print(f'  KLD Loss:   {avg_kld:.4f}')\n",
+    "        print(f'  LR:         {current_lr:.6f}')\n",
+    "\n",
+    "    return vae, history"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "X0zdh0W5M0Gg"
+   },
+   "source": [
+    "## Load MNIST Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "7u862w2uIgp6",
+    "outputId": "06d894fb-d6d2-417c-b44f-1709a8c8bfea"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "STEP 1: Loading MNIST Dataset\n",
+      "============================================================\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 9.91M/9.91M [00:01<00:00, 4.96MB/s]\n",
+      "100%|██████████| 28.9k/28.9k [00:00<00:00, 127kB/s]\n",
+      "100%|██████████| 1.65M/1.65M [00:01<00:00, 1.25MB/s]\n",
+      "100%|██████████| 4.54k/4.54k [00:00<00:00, 12.2MB/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset loaded: 60000 training images\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"=\"*60)\n",
+    "print(\"STEP 1: Loading MNIST Dataset\")\n",
+    "print(\"=\"*60)\n",
+    "\n",
+    "transform = transforms.Compose([\n",
+    "    transforms.ToTensor(),\n",
+    "    transforms.Normalize((0.5,), (0.5,))\n",
+    "])\n",
+    "\n",
+    "train_dataset = datasets.MNIST('./data', train=True, download=True, transform=transform)\n",
+    "train_loader = DataLoader(train_dataset, batch_size=128, shuffle=True,\n",
+    "                          num_workers=4, pin_memory=True)\n",
+    "\n",
+    "print(f\"Dataset loaded: {len(train_dataset)} training images\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TKAQ-3DVM4Hw"
+   },
+   "source": [
+    "## Train and Save the Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "5iCkJSC-IiSi",
+    "outputId": "4fc236a5-06d7-4f87-845e-90f92d19b6ed"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "============================================================\n",
+      "STEP 2: Training Convolutional VAE\n",
+      "============================================================\n",
+      "Training Convolutional VAE...\n",
+      "Model parameters: 1,780,545\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/40: 100%|██████████| 469/469 [00:08<00:00, 53.43it/s, loss=132.39, recon=90.13, kld=14.09]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/40:\n",
+      "  Total Loss: 2943.1498\n",
+      "  Recon Loss: 121.7197\n",
+      "  KLD Loss:   940.4768\n",
+      "  LR:         0.000998\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 2/40: 100%|██████████| 469/469 [00:06<00:00, 67.28it/s, loss=112.49, recon=71.13, kld=13.79]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 2/40:\n",
+      "  Total Loss: 122.1088\n",
+      "  Recon Loss: 77.7753\n",
+      "  KLD Loss:   14.7778\n",
+      "  LR:         0.000994\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 3/40: 100%|██████████| 469/469 [00:06<00:00, 67.59it/s, loss=115.78, recon=70.81, kld=14.99]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 3/40:\n",
+      "  Total Loss: 114.2365\n",
+      "  Recon Loss: 69.8908\n",
+      "  KLD Loss:   14.7819\n",
+      "  LR:         0.000986\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 4/40: 100%|██████████| 469/469 [00:06<00:00, 69.27it/s, loss=108.67, recon=63.52, kld=15.05]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 4/40:\n",
+      "  Total Loss: 110.6938\n",
+      "  Recon Loss: 66.2842\n",
+      "  KLD Loss:   14.8032\n",
+      "  LR:         0.000976\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 5/40: 100%|██████████| 469/469 [00:06<00:00, 68.73it/s, loss=103.77, recon=59.71, kld=14.68]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 5/40:\n",
+      "  Total Loss: 108.0681\n",
+      "  Recon Loss: 63.5542\n",
+      "  KLD Loss:   14.8380\n",
+      "  LR:         0.000962\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 6/40: 100%|██████████| 469/469 [00:06<00:00, 68.48it/s, loss=112.30, recon=66.08, kld=15.41]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 6/40:\n",
+      "  Total Loss: 106.2030\n",
+      "  Recon Loss: 61.6316\n",
+      "  KLD Loss:   14.8571\n",
+      "  LR:         0.000946\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 7/40: 100%|██████████| 469/469 [00:06<00:00, 69.01it/s, loss=104.75, recon=61.30, kld=14.48]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 7/40:\n",
+      "  Total Loss: 104.6890\n",
+      "  Recon Loss: 60.1469\n",
+      "  KLD Loss:   14.8474\n",
+      "  LR:         0.000926\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 8/40: 100%|██████████| 469/469 [00:06<00:00, 67.49it/s, loss=107.79, recon=62.64, kld=15.05]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 8/40:\n",
+      "  Total Loss: 103.3347\n",
+      "  Recon Loss: 58.7162\n",
+      "  KLD Loss:   14.8728\n",
+      "  LR:         0.000905\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 9/40: 100%|██████████| 469/469 [00:06<00:00, 68.33it/s, loss=101.81, recon=58.25, kld=14.52]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 9/40:\n",
+      "  Total Loss: 102.2517\n",
+      "  Recon Loss: 57.5809\n",
+      "  KLD Loss:   14.8903\n",
+      "  LR:         0.000880\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 10/40: 100%|██████████| 469/469 [00:06<00:00, 67.02it/s, loss=102.57, recon=59.25, kld=14.44]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 10/40:\n",
+      "  Total Loss: 101.3169\n",
+      "  Recon Loss: 56.5741\n",
+      "  KLD Loss:   14.9143\n",
+      "  LR:         0.000854\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 11/40: 100%|██████████| 469/469 [00:07<00:00, 66.32it/s, loss=95.58, recon=52.09, kld=14.49]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 11/40:\n",
+      "  Total Loss: 100.4484\n",
+      "  Recon Loss: 55.7486\n",
+      "  KLD Loss:   14.8999\n",
+      "  LR:         0.000825\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 12/40: 100%|██████████| 469/469 [00:06<00:00, 69.61it/s, loss=106.48, recon=61.20, kld=15.09]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 12/40:\n",
+      "  Total Loss: 99.7889\n",
+      "  Recon Loss: 54.9504\n",
+      "  KLD Loss:   14.9462\n",
+      "  LR:         0.000794\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 13/40: 100%|██████████| 469/469 [00:06<00:00, 70.44it/s, loss=98.21, recon=54.85, kld=14.45]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 13/40:\n",
+      "  Total Loss: 99.0021\n",
+      "  Recon Loss: 54.1854\n",
+      "  KLD Loss:   14.9389\n",
+      "  LR:         0.000761\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 14/40: 100%|██████████| 469/469 [00:06<00:00, 69.77it/s, loss=95.96, recon=52.44, kld=14.50]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 14/40:\n",
+      "  Total Loss: 98.4553\n",
+      "  Recon Loss: 53.6580\n",
+      "  KLD Loss:   14.9324\n",
+      "  LR:         0.000727\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 15/40: 100%|██████████| 469/469 [00:06<00:00, 68.60it/s, loss=100.39, recon=54.58, kld=15.27]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 15/40:\n",
+      "  Total Loss: 97.7684\n",
+      "  Recon Loss: 52.9638\n",
+      "  KLD Loss:   14.9349\n",
+      "  LR:         0.000691\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 16/40: 100%|██████████| 469/469 [00:07<00:00, 66.87it/s, loss=98.62, recon=54.15, kld=14.82]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 16/40:\n",
+      "  Total Loss: 97.1275\n",
+      "  Recon Loss: 52.3211\n",
+      "  KLD Loss:   14.9355\n",
+      "  LR:         0.000655\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 17/40: 100%|██████████| 469/469 [00:06<00:00, 68.02it/s, loss=101.81, recon=56.33, kld=15.16]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 17/40:\n",
+      "  Total Loss: 96.7112\n",
+      "  Recon Loss: 51.7768\n",
+      "  KLD Loss:   14.9782\n",
+      "  LR:         0.000617\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 18/40: 100%|██████████| 469/469 [00:06<00:00, 68.33it/s, loss=95.98, recon=52.03, kld=14.65]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 18/40:\n",
+      "  Total Loss: 96.2307\n",
+      "  Recon Loss: 51.2898\n",
+      "  KLD Loss:   14.9803\n",
+      "  LR:         0.000578\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 19/40: 100%|██████████| 469/469 [00:06<00:00, 67.65it/s, loss=96.31, recon=51.58, kld=14.91]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 19/40:\n",
+      "  Total Loss: 95.7229\n",
+      "  Recon Loss: 50.7185\n",
+      "  KLD Loss:   15.0015\n",
+      "  LR:         0.000539\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 20/40: 100%|██████████| 469/469 [00:06<00:00, 68.59it/s, loss=95.81, recon=49.71, kld=15.36]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 20/40:\n",
+      "  Total Loss: 95.2729\n",
+      "  Recon Loss: 50.2923\n",
+      "  KLD Loss:   14.9936\n",
+      "  LR:         0.000500\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 21/40: 100%|██████████| 469/469 [00:06<00:00, 70.03it/s, loss=96.79, recon=50.91, kld=15.30]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 21/40:\n",
+      "  Total Loss: 94.8571\n",
+      "  Recon Loss: 49.7916\n",
+      "  KLD Loss:   15.0218\n",
+      "  LR:         0.000461\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 22/40: 100%|██████████| 469/469 [00:06<00:00, 69.83it/s, loss=92.85, recon=49.92, kld=14.31]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 22/40:\n",
+      "  Total Loss: 94.3545\n",
+      "  Recon Loss: 49.3219\n",
+      "  KLD Loss:   15.0109\n",
+      "  LR:         0.000422\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 23/40: 100%|██████████| 469/469 [00:06<00:00, 67.65it/s, loss=89.15, recon=46.06, kld=14.36]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 23/40:\n",
+      "  Total Loss: 93.9520\n",
+      "  Recon Loss: 48.9202\n",
+      "  KLD Loss:   15.0106\n",
+      "  LR:         0.000383\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 24/40: 100%|██████████| 469/469 [00:06<00:00, 70.42it/s, loss=97.04, recon=50.59, kld=15.48]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 24/40:\n",
+      "  Total Loss: 93.6698\n",
+      "  Recon Loss: 48.5562\n",
+      "  KLD Loss:   15.0379\n",
+      "  LR:         0.000345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 25/40: 100%|██████████| 469/469 [00:07<00:00, 66.38it/s, loss=93.63, recon=48.76, kld=14.96]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 25/40:\n",
+      "  Total Loss: 93.2344\n",
+      "  Recon Loss: 48.0729\n",
+      "  KLD Loss:   15.0538\n",
+      "  LR:         0.000309\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 26/40: 100%|██████████| 469/469 [00:06<00:00, 70.99it/s, loss=95.92, recon=50.00, kld=15.31]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 26/40:\n",
+      "  Total Loss: 92.9040\n",
+      "  Recon Loss: 47.7253\n",
+      "  KLD Loss:   15.0596\n",
+      "  LR:         0.000273\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 27/40: 100%|██████████| 469/469 [00:06<00:00, 67.86it/s, loss=94.65, recon=48.76, kld=15.30]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 27/40:\n",
+      "  Total Loss: 92.5177\n",
+      "  Recon Loss: 47.3440\n",
+      "  KLD Loss:   15.0579\n",
+      "  LR:         0.000239\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 28/40: 100%|██████████| 469/469 [00:07<00:00, 66.80it/s, loss=91.64, recon=47.16, kld=14.83]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 28/40:\n",
+      "  Total Loss: 92.2325\n",
+      "  Recon Loss: 46.9383\n",
+      "  KLD Loss:   15.0981\n",
+      "  LR:         0.000206\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 29/40: 100%|██████████| 469/469 [00:06<00:00, 68.74it/s, loss=91.66, recon=46.53, kld=15.04]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 29/40:\n",
+      "  Total Loss: 91.9400\n",
+      "  Recon Loss: 46.6532\n",
+      "  KLD Loss:   15.0956\n",
+      "  LR:         0.000175\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 30/40: 100%|██████████| 469/469 [00:06<00:00, 70.07it/s, loss=90.74, recon=45.59, kld=15.05]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 30/40:\n",
+      "  Total Loss: 91.6200\n",
+      "  Recon Loss: 46.2720\n",
+      "  KLD Loss:   15.1160\n",
+      "  LR:         0.000146\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 31/40: 100%|██████████| 469/469 [00:06<00:00, 67.66it/s, loss=92.41, recon=46.05, kld=15.45]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 31/40:\n",
+      "  Total Loss: 91.4836\n",
+      "  Recon Loss: 46.0025\n",
+      "  KLD Loss:   15.1604\n",
+      "  LR:         0.000120\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 32/40: 100%|██████████| 469/469 [00:07<00:00, 66.39it/s, loss=92.47, recon=45.54, kld=15.65]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 32/40:\n",
+      "  Total Loss: 91.1364\n",
+      "  Recon Loss: 45.7416\n",
+      "  KLD Loss:   15.1316\n",
+      "  LR:         0.000095\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 33/40: 100%|██████████| 469/469 [00:06<00:00, 69.19it/s, loss=92.42, recon=46.17, kld=15.42]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 33/40:\n",
+      "  Total Loss: 90.9708\n",
+      "  Recon Loss: 45.5071\n",
+      "  KLD Loss:   15.1546\n",
+      "  LR:         0.000074\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 34/40: 100%|██████████| 469/469 [00:06<00:00, 69.59it/s, loss=91.69, recon=45.05, kld=15.55]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 34/40:\n",
+      "  Total Loss: 90.7663\n",
+      "  Recon Loss: 45.2975\n",
+      "  KLD Loss:   15.1563\n",
+      "  LR:         0.000054\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 35/40: 100%|██████████| 469/469 [00:07<00:00, 66.66it/s, loss=89.61, recon=45.11, kld=14.83]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 35/40:\n",
+      "  Total Loss: 90.6349\n",
+      "  Recon Loss: 45.1655\n",
+      "  KLD Loss:   15.1565\n",
+      "  LR:         0.000038\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 36/40: 100%|██████████| 469/469 [00:06<00:00, 70.33it/s, loss=91.76, recon=45.89, kld=15.29]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 36/40:\n",
+      "  Total Loss: 90.4321\n",
+      "  Recon Loss: 44.9360\n",
+      "  KLD Loss:   15.1654\n",
+      "  LR:         0.000024\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 37/40: 100%|██████████| 469/469 [00:06<00:00, 68.09it/s, loss=90.18, recon=44.17, kld=15.34]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 37/40:\n",
+      "  Total Loss: 90.3418\n",
+      "  Recon Loss: 44.8862\n",
+      "  KLD Loss:   15.1519\n",
+      "  LR:         0.000014\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 38/40: 100%|██████████| 469/469 [00:06<00:00, 70.10it/s, loss=86.92, recon=42.46, kld=14.82]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 38/40:\n",
+      "  Total Loss: 90.3192\n",
+      "  Recon Loss: 44.7839\n",
+      "  KLD Loss:   15.1784\n",
+      "  LR:         0.000006\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 39/40: 100%|██████████| 469/469 [00:06<00:00, 68.99it/s, loss=88.95, recon=43.57, kld=15.13]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 39/40:\n",
+      "  Total Loss: 90.2579\n",
+      "  Recon Loss: 44.7357\n",
+      "  KLD Loss:   15.1741\n",
+      "  LR:         0.000002\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch 40/40: 100%|██████████| 469/469 [00:06<00:00, 68.30it/s, loss=96.90, recon=50.91, kld=15.33]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 40/40:\n",
+      "  Total Loss: 90.1953\n",
+      "  Recon Loss: 44.6755\n",
+      "  KLD Loss:   15.1733\n",
+      "  LR:         0.000000\n",
+      "\n",
+      "✓ VAE checkpoint saved!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"\n",
+    "\" + \"=\"*60)\n",
+    "print(\"STEP 2: Training Convolutional VAE\")\n",
+    "print(\"=\"*60)\n",
+    "\n",
+    "latent_dim = 128\n",
+    "vae = ConvVAE(latent_dim=latent_dim, img_channels=1)\n",
+    "beta = 3\n",
+    "vae, history = train_conv_vae(vae, train_loader, epochs=40, device=device, beta=beta, lr=1e-3)\n",
+    "\n",
+    "torch.save({\n",
+    "    'model_state_dict': vae.state_dict(),\n",
+    "    'latent_dim': latent_dim,\n",
+    "    'history': history,\n",
+    "}, f'conv_vae_checkpoint_{beta}.pt')\n",
+    "print(\"\n",
+    "✓ VAE checkpoint saved!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "S5V6ZPq_M7Cl"
+   },
+   "source": [
+    "## Visualize Reconstruction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 573
+    },
+    "id": "cxGf-IkMIi6s",
+    "outputId": "ea84a74d-8854-43ce-fb51-23ca5ccdf136"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "Visualizing VAE Reconstruction\n",
+      "============================================================\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAACVEAAAKICAYAAABzbCh9AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAuIwAALiMBeKU/dgAAThNJREFUeJzt/Hm4HeKh//1nsYVIQkTMSUONpygJR0LR0pAU0Riy6aG0lBNKNCntqRI1dVBJ9DhHzcWXIxI0yKC0qtoMbSXkqHkIkpgiESRBIlnPX9/nun4/+viw1s7a2ffr9ff7WvedyF577bU/VqVarVbbAQAAAAAAAAAAFGqNRl8AAAAAAAAAAACgkYyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAitbUqIMrlUqjjgYAAAAAAAAAAFqharXakHN9EhUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFC0pkZfgNXLGWecEXWjR49u4Zt8vEqlEnXVarWu544YMSLqLr/88qh7++23a7kOALAa6NatW9TtsssudT131qxZUffmm2/W9VwAAABat+bm5qi77bbbom7atGlRd9lll0Xd2LFjow7aknXXXTfq+vTpE3WTJ0+OurXXXjvq7rjjjqg7+uijo+7DDz+MOqA2PXr0iLp+/fpF3SGHHBJ1hx12WNTV2zPPPBN1F1xwQdT9z//8Ty3XoZXzSVQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0SrVarXakIMrlUYcS40OOOCAqLvzzjujbt11163lOqudhx56KOouueSSqJs8eXIt14HPbM0116xrlxo0aFDU7bTTTnU99xvf+EbUbb311nU9t96eeOKJqDvvvPOi7o477qjlOrBKbLTRRlH39a9//RObk046KXqsDh06RF3nzp2j7nOf+1zUpa+vX3rppagbNmxY1I0fPz7qAAAAqK/u3btH3ahRo6Ju8ODBtVynxfXo0SPq5s6d28I3oUQbbLBB1P3Lv/xL1B111FFRd+yxx0bd+uuvH3Wp9H2m9NfMY8aMibr0zwulSd8jvvzyy6Puq1/9atSlv8tv0OSk7lasWBF1Q4YMibrrr7++lusUr1H/rnwSFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFC0SrVarTbk4EqlEceyigwePDjqhg0bFnV9+vSJukceeSTq5s2bF3Xbbrtt1G2//fZRl1q6dGnUHXzwwZ/YPPTQQ7Veh4K0b98+6kaNGhV1p5xySi3XoUFmzZoVdV/5ylei7p133qnhNvDxDjzwwKj7xS9+EXVf/OIXa7lOq5C+vk5f/n/44YdRN3HixKg7/PDDow4AAGB11L1796hrbm7+xObII4+MHmvPPfeMutScOXOi7rLLLou69D3E5O+kXbt27caOHRt1tG1rrrlm1PXu3TvqhgwZEnX9+vWLui222CLqWrt6v8+Uvkd8wAEHRN2MGTOiDtqKn//851F31lln1fXcej8XtBUffPBB1KW/R/vb3/5Ww23arkb9u/JJVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRKtVqtdqQgyuVRhxLK9OlS5eo22mnnaLu6aefjrr58+dHXY8ePaJu6NChUTd8+PCoS02aNOkTm4EDB9b1TNq2n//851F31llntfBNVk/vvvtuXR+vc+fOUbds2bKoW7x4cdSdfvrpUTdmzJiog5YwY8aMqNt1113rdubMmTOjbvLkyVH3xBNP1HKdz+z73/9+1PXu3TvqPvjgg6g79thjo+7OO++MOqB2ffv2jbrPfe5zUde9e/e6npt26c9tqfR5ctSoUXU9F1q7Aw44IOp+/etfR93nP//5qLvrrruibtNNN426efPmRd0LL7wQdbNmzYq6e++9N+oWLFgQdUDt0vdqjzzyyKjbc889a7nO/485c+ZE3fTp06Mufd2SPh60hPQ9nEMPPTTqRowYUcNteOyxx6Ju5513ruu5Rx99dNTdfvvtdT0XWrvjjjsu6q6++uqoW2uttaIu/Z363XffHXWzZ8+OulT6XtSQIUPqem4q/Tn6gQceaOGbrJ4aNGXySVQAAAAAAAAAAEDZjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0ZoafQHKtmjRoqj7y1/+0rIX+SfmzJkTdc8//3wL3+TjbbXVVg05l7ZryZIljb7C/6f0OePll1+OuquvvrqG23zU3XffHXWVSiXqBg4cGHWzZ8+OunvvvTfqYHWw3XbbRd2CBQui7qSTTvrEZuLEidFjffjhh1HXKDNmzIi6SZMmRd3nP//5qLvhhhui7qmnnoq6J554IupgdTB8+PCoO/LII6Nuzz33rOU6xRs5cmTUTZ06NeqmT59ey3WgxW244YZRl35tpK8NUl//+tfr+njLli2Luvbt29f13Oeeey7qBgwYEHUvvPBCLdeBNi19vkpfg6XGjRsXdaNGjfrEprW/fkj/7pI/K/xf6fsV1Wq1hW+yevrv//7vqJs8eXLUpb+XS9+zB2pz0003Rd3cuXOjbuONN466MWPGRF2jDBo0KOqGDBnSshehTfFJVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRmhp9AWjN2rdvH3WHH354C98EVo3nnnuuIecuWLAg6vbcc8+oe/7552u5zme28cYbR12HDh2i7rrrrou6ZcuWRR20Jen33r///e9Rt2jRohpus3rZaKONoq5bt251Pbdjx45Rd+2110Zdv379om7p0qVRB59G3759o27s2LFR16NHj1qu0+LmzJkTdePGjYu6v/71r7Vc5yP69OkTdcOHD4+69M87ffr0qIPWbr/99ou6nXbaqa7nXnjhhVH34IMPRl2lUom6119/PerSn++22267qLvgggui7sc//nHUnXjiiVEHJRo8eHDUpd/z99prr6ibO3du1DVC9+7doy59/Tpt2rRargO0a9duypQpUffLX/4y6n73u99F3fLly6OuU6dOUVdvW2+9dUPOhbbigQceaPQVVqnm5uZGX4E2yCdRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEVravQFaB369esXdfvuu28L36R12XvvvaPuy1/+cl3PffHFF6Pu8ssvr+u5sMsuuzTk3HXWWSfqRowY0cI3qU36XLrppptG3b333ht1b775ZtRdddVVUff8889H3euvvx510BLuv//+Rl9htTV16tSo22CDDaJu/PjxUTdw4MCo69OnT9R9/etfj7pbb7016uDT+NznPlfXxxs1alTUjRs3Lurmzp1b1661O/LII+v6eNOnT6/r40GjrLXWWlH3b//2b3U996GHHoq6Cy64IOpWrFhRy3U+s8cffzzq/vznP0fdaaedFnXbbrtt1AG1awuvmZqbm6Pu0ksvjbr0zzp69Oiog0/j+uuvj7pvf/vbdT130aJFUZe+F3XLLbdE3e9///uoe//996Ou3k488cSGnPvuu+825Fxg1WhqyuYp55xzTtQNGjSohtt8dvPnz4+62bNnt/BNaAk+iQoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAoWlOjL0DLOuigg6Ju/PjxUbfmmmvWcBuee+65qBswYEDUzZ49u5brwEe8+eabDTm3Y8eOUXfssce28E1al/S5IJX+/b300ktRd/XVV0fdpZdeGnUffvhh1AGty4QJE6Ju4MCBdT33C1/4Ql0fDz6NsWPH1rXj4/Xt2zfqBg8eXNdz58yZU9fHg0bp1atX1A0aNCjq5s6dG3XHHHNM1K1YsSLqWrsDDjgg6nbccceoO/fcc2u5DtCuXbtx48ZF3fDhw6Nu5MiRUff9738/6hL1vtu0adOirrm5OerS7wnwafzwhz+Muoceeijqpk6dGnUffPBB1JX2775fv34NOfeNN95oyLlAbfbee++ou/jii+v6ePW2bNmyqDv11FOjzu/yV08+iQoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAoWlOjL8Bn06lTp6gbNmxY1K255pq1XIfQrFmzom727NktfBP4eKNHj466bbfdNuq+853v1HKd1c7ixYuj7tlnn4267bffPurWXXfdqEv17Nkz6i6++OKo69ChQ9RdcMEFUbdixYqoA1aNu+++O+quuuqqFr4J0NYMHjy4Ieemr4mhtUu/hpYuXRp1p59+etTNmzcv6tqKHXfcsdFXAP7/jBs3LurS58m0S19DJO/ZDx8+PHqsOXPmRF1zc3PUzZ07N+qgJSxcuDDq/s//+T8tfJO2bffdd4+6gw46KOqq1WrULVq0KOrS986BVeO73/1u1J133nlRt+GGG9ZynRa3fPnyqLvzzjtb+CY0kk+iAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIrW1OgL8Nl07tw56rbbbrsWvgmfxiabbBJ16623XtS98847tVwHPmLFihVRd9ppp0XdXXfdFXXrr79+1H3uc5+Lusceeyzq6m3BggVR99e//jXq9txzz6jbYIMNom7HHXeMup/85CdRt84660TdOeecE3Xjxo2Lun/84x9RB7QulUqlVT8esOr07ds36oYPH17Xc9PXGnPnzq3rudAo+++/f9Q99dRTUZf+fFea/v371/XxJk+eXNfHgxJNnz496i677LKoGzlyZNRNnTo16nr06PGJzbRp06LHam5ujjqvb4D/q1OnTg05980334y6WbNmtfBNgHbt2rXbddddo+7iiy+OunS70Nqtu+66UffTn/406s4+++xarkOD+CQqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhNjb4An82rr74adYceemjUTZ48Oeo22WSTqKu39957L+qefvrpqJs4cWLUHXzwwVH3xS9+Mer23nvvqLvyyiujbsiQIZ/YvPPOO9FjwaexfPnyqJs0aVIL36RtmzZtWl0fL/3v8e6770bdqFGjom7ttdeOunPPPTfqvvGNb0TdypUrow7qbYcddoi6LbbYIupefvnlqHv22Wejrt569OgRddVqta7n3n333XV9PGDVGT58eF0fb86cOQ05F1q7c845J+o233zzFr7J6ql///5Rt88++0TdlClTom7WrFlRB9Ru7ty5dX289Gej5P2e5ubm6LHq/WcAVl977rln1I0YMSLq1lgj+xyO9D3Y9HcKwKrx6KOPRl2lUqlrl0rf60lff6XSP8chhxwSdWeffXYt16FBfBIVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAULSmRl+AljVr1qyo69+/f9TttNNOtVznM3vrrbei7t57763ruSNGjIi6l19+Oeq22GKLqDvqqKOi7pZbbvnEZuLEidFjAfxfV155ZdQ1NzdH3Ze//OWoO/LII6PuhBNOiLolS5ZEHaun3XffPeoGDBgQdem/50T6/b5Lly5Rt3Dhwqi77bbbom7SpElR9/zzz0fd+eefH3WpF154IeqeeOKJup4L1C59Lh08eHBdzz3zzDOjbu7cuXU9F1q7yZMnN/oKq7UvfelLUde+ffuo++Mf/xh1K1asiDqgdn369GnIuZdddtknNl63AJ/WV77ylajbd999o27lypVRl752ueiii6IOaF3S99dPOumkqPvtb38bdQ8//HDUNeo1U7Vabci5rBo+iQoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAoWqVarVYbcnCl0ohjoUUMGTIk6v77v/+7ruceeuihn9hMnDixrmfC6qBXr15Rt+6660bdlClTarlOm/Wd73wn6q666qq6nrveeutF3ZIlS+p6LrVZf/31o27UqFFRd+yxx9ZynY9YuHBhXR+vnrp16xZ1a665ZtStWLEi6j788MOoa9++fdSlrr/++qg76aST6nou8M9179496qZOnRp1PXr0iLpp06ZF3V577RV1AO3atWt34IEHRt2kSZOi7r333ou6XXfdNeqef/75qAP+ueHDh0fdyJEjo27OnDlRl77GGTdu3Cc2zc3N0WMBbV/nzp2j7tlnn4269H2m9Pe4b7zxRtTts88+UZd65ZVXom7p0qV1PRdYNfbff/+ou//++1v4Jh/vH//4R9TtsssuLXyTtq1BUyafRAUAAAAAAAAAAJTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUranRF4C2YP/992/0FWC11qFDh6j79a9/HXUDBw6MurXXXjvq+vfvH3VTpkyJurZi++23b/QVaAV23nnnqJs0aVLUbb755lH3zDPPRN3QoUOj7v7774+6Rkif0w477LCoO/7446Ouffv2UVdvEyZMaMi5wD/X3NwcdT169KjrucOHD6/r4wFt21prrRV16evDNdbI/t/TK6+8Muqef/75qAP+ub59+0bdyJEjo27atGlRd9lll0XdbbfdFnUA7drl763+6le/irpu3brVcp3PbKONNoq6p556qq7n3nrrrVGXfk9ILViwIOrmzJlT13OhNHfccUdDzq1Wq1E3atSoFr4JjeSTqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiNTX6AqX4yU9+EnXDhg2LutmzZ0fdrrvuGnXUpn///o2+AqzWzj333Kj75je/Wddzb7/99qibNWtWXc9t7bbccsuoO/7441v2IqwW7rvvvqjbeOONo+6Xv/xl1P3qV7+KuldffTXqWrN77rkn6g4//PAWvsmqcc0110Tdl7/85agbPnx4LdeBNq1v375RN3LkyLqeO2rUqKibPn16Xc8F2rbm5uaoO+igg+p67ksvvVTXx4MSde/ePerq/do+fby5c+fW9VygdenYsWPU9erVK+q22WabqBs9enTUde7cOepK841vfKOuXWrevHlRd8MNN0Td+eefH3UrV66MOlY/m2++edT16NGjhW+yahx77LFRlz4319vSpUuj7sYbb2zhm9BIPokKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKFpToy+wujvyyCOj7j/+4z+ibq211oq6jTfeOOq22mqrqJs9e3bUtRW9e/eOurFjx0Zdx44da7nOR1x33XVR98ADD9T1XGiUjTbaqCHnbrDBBlG3ePHiFr5J63LrrbdG3YYbbljXc2+44YaoW7p0aV3PpTabbLJJ1FWr1agbM2ZM1L366qtRV0/p67T27dtH3RFHHBF155xzTtRts802UZf+t3j44Yej7pe//GXUDRgwIOqOP/74qBs6dGjU9e/fP+puueWWqPvwww+j7pJLLok6aAndu3ePuvTnndScOXOibvTo0XU9F6Bdu3bt9t5777o+3rx586Lupptuquu5UKLm5uaoGzx4cNSNGzcu6qZPnx516f1S6Ws1oDZbbLFF1N11111Rt+uuu9ZwG9qK9N/Vj3/846i7/fbbo+6xxx6LOj7q85//fNT16dMn6tL3OLfbbruo23zzzaOuUa8fKpVK1KXvObd2F154YaOvQCvgk6gAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAojU1+gKruwcffDDqXnnllajr2bNn1G2yySZRN2HChKj72te+FnUvv/xy1DXKDjvsEHU/+tGPom6rrbaq5Tof8eabb0bdqFGjou69996r5TrQajz66KMNOXefffaJuv322y/q/vjHP9ZynRZ3xBFHRN2WW27Zshf5Jy688MKoq1arLXwTPo3bbrst6pqbm6Pu1ltvjbq//OUvUVdPu+yyS9TttttuLXyTj1epVKLu8ssvj7rzzjsv6hYtWhR1t99+e9Q9/fTTUTds2LCoS18f/uAHP4i69N8yNFL677RHjx51PffMM8+Murlz59b1XKBt23bbbaNu8ODBdT13/PjxUffOO+/U9VxoS/r27Rt1I0eOjLpp06ZFXb1fs3fv3r2uj+e1EKwa3/3ud6Nu1113bdmLtDJPPfVU1B1zzDEtfJNVY+utt466er+WHDhwYNSl37Mee+yxWq7TZm2zzTaf2Nx3333RY6W/o2f1NHbs2Ki79NJLW/gmrA58EhUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQtEq1Wq025OBKpRHHNsxZZ50VdT//+c9b+CYf75lnnom6G2+8MeruuuuuqNtuu+2i7jvf+U7U7brrrlG3+eabR129/frXv4660047rYVvAq1L165do27KlClRlz63pP7xj39E3XnnnRd148ePj7ojjjgi6vbdd9+oGzJkSNQ1NTVFXeqGG26IuvS5vkEvXfgn1llnnajba6+9WvgmpGbNmhV1CxYsaOGb1KZnz55Rt/XWW0fd/Pnzo+6xxx6LOmgJffv2jbpp06bV9dxRo0ZF3fe///26ngvQrl27dt/61rei7vrrr4+6FStWRN0hhxwSdb/73e+iDkrU3NwcdbfddlvUjRs3rq7nNuq1VY8ePT6xmTt3bl3PhBL967/+a9TV+2u8UZ544omoO+CAA6Lu9ddfr+U6xUvft3r33XejbuHChbVcp81Kfh+dvq7n462xRvaZPCtXrmzhm3y8v//971E3cODAqEvfI2bVaNTvA30SFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFC0SrVarTbk4EqlEcc2TPfu3aPuhBNOiLrTTz896rp27Rp11ObUU0+NultuuSXqFi9eXMt1oM367ne/G3X/+Z//2cI3+Xgffvhh1L377rtR17lz56hramqKunq7+eabo+6UU06JuqVLl9ZyHQBo88aOHRt1gwcPjro5c+ZE3V577RV1c+fOjTqAT+ORRx6Jul122SXqpkyZEnX77LNP1AH/XHNzc9TddtttUZe+dkn16NGjrueeeeaZUZe+pgNqs80220TdU0891cI3qc1NN90UdWeffXbUvfbaa7VcB1qVc8455xOb9Ptz+vuY0qSbjvnz50fdtGnTou6KK66IukcffTTq3njjjaijdWnQlMknUQEAAAAAAAAAAGUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFq1Sr1WpDDq5UGnFsm7H++utH3UknnRR1Bx54YNR99atfjbrW7q677oq6qVOnRt2vfvWrqFu+fHnUAR8v/d7Rs2fPqLv33nujbtttt426tmLo0KFRd80110TdsmXLarkOALR5ffv2jbpp06bV9dyjjjoq6saOHVvXcwHatWvXbocddoi6//3f/426tdZaK+quvfbaqEvfUwNql77WSF8z9ejRI+rGjRsXdaNGjYq66dOnRx2waqTvJafPBYMGDYq6559/PuouvPDCqLvllluirkG/7oVWr3///lF32GGHRV1pPydcdNFFUXfFFVdE3euvv17LdShMo763+SQqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGiVarVabcjBlUojjgWA/9cWW2wRdSeffHLUHXPMMVG31VZbRd1zzz0Xdeeff37UjR07Nuo+/PDDqAMA6mPkyJFRN3z48KgbN25c1DU3N0cdQEs4+OCDo+6ee+6p67lDhw6Nuv/6r/+q67kAAABArkFTJp9EBQAAAAAAAAAAlM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABStqdEXAIBGmTdvXtSdd955de0AgDL07ds36oYPH17Xc+fMmVPXxwNYHSxfvjzqxo8f37IXAQAAAFZbPokKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKFpToy8AAAAAbdH06dOjbty4cVE3ePDgqOvRo0fUATTSq6++GnVz5syJuilTpkTd3Llzow4AAAAoj0+iAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpWqVar1YYcXKk04lgAAAAAAAAAAKCVatCUySdRAQAAAAAAAAAAZTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoTY2+AADUW1NT9u3tJz/5SdTNmzcv6m644Yaoe++996IOAAAAAAAAgFXDJ1EBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARatUq9VqQw6uVBpxLAAFGDJkSNRdccUVdT33hRdeiLoxY8ZE3SWXXBJ177zzTtQBAAAAAABQtrXWWivqzjjjjKg755xzou6hhx6KuqOPPjrqli5dGnWsnho0ZfJJVAAAAAAAAAAAQNmMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRKtVqtdqQgyuVRhwLQAGGDh0adZdddlnLXqRGU6ZMibrhw4dH3d///vdargMAAAAAQB106tQp6iZMmBB1M2bMiLpbb7016h555JGoW7FiRdQBq8Yaa2SfoXPCCSdE3VVXXVXLdT4i3Yh8/etfj7p77rmnluvQyjVoyuSTqAAAAAAAAAAAgLIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiVarVarUhB1cqjTgWgAK0b98+6oYOHRp13/3ud6OuZ8+eUVdv8+bNi7qdd9456hYtWlTDbYBG2XbbbaPutNNOi7ouXbpE3fvvvx91J510UtRNmzYt6r70pS9FHQAAQGvS1NT0ic2ZZ54ZPdY999wTdY8//njUpW666aaoS3/99OKLL0bdtddeG3Vz5syJOmik3//+91GXvv/x7rvvRl3Xrl2jbtKkSVF36KGHRh2wauyxxx5Rl74Hm0pfa1xyySVRd9ddd0Vd+tzH6qlBUyafRAUAAAAAAAAAAJTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUrVKtVqsNObhSacSxAPCprbvuulHXtWvXqLv66qujbsCAAVGXuvnmm6Pu9NNPj7q33367lusAoQsuuCDqhg0bFnXpc1oqfV2f/tjx+uuvR93mm28edQAAAKtCz549o+6GG274xGafffaJHuvaa6+NuiFDhkRdasWKFVFX718//eEPf4i6gQMHRt2yZctquQ58rO7du0fdzJkzo65z585Rd+edd0bdAQccEHXpe93f/OY3o+7WW2+NOuDj9e3bN+omT54cdeutt14t1/mI7bffPuqee+65up5L29agKZNPogIAAAAAAAAAAMpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACK1tToC7B6WWONbHd35JFHRt3WW28ddaeffnrUbbrpplGXevDBB6PusMMOi7q33367htsAjbJ06dK6dgcddFDU/exnP4u6H/7wh1F37LHHRt19990XdTfffHPUAR8v/do955xzoq5arUbdggULoq6pKftRoUuXLlEHQH107tw56i6++OKo++CDD6LurLPOijpIdejQIerS10zp10bv3r2j7rbbbou6a665JupWrFgRdT179oy6oUOHRl3qrrvuirqHHnqorufC6uCQQw6JulGjRkVd8p54+vPdn/70p6irt6uuuirqXnrppag77bTTou6rX/1q1K2//vpRN3/+/KiDT+PUU0+Nuq5du0ZdpVKJuvT3VPWWvtd96623tvBNoG0bPXp01K233np1PffJJ5+MuiVLltT1XGgkn0QFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFK1SrVarDTm4UmnEsfwTe+21V9RdcMEFUbf//vvXcp2PSP+9NOifc7vx48dH3eGHH96yFwHalA033DDqnnzyyajr1q1b1E2YMCHqDj300KiD0vTu3Tvq7r333qhLv3bvv//+qDviiCOirlOnTlH3yiuvRF36Ou2WW26JuuOOOy7qgH9u++23j7rZs2dH3bJly2q5TvHS/x6/+tWvoq5fv35Rt8cee0TdzJkzow623XbbqLvhhhuirk+fPlHXqPeOLrrooqj76U9/GnWXXXZZ1J188slRlzrrrLOibvTo0XU9FxqpZ8+eUTdlypSo23TTTaMueb56/PHHo8fabbfdom758uVR1yjpz8fp65vNNtss6ubPnx910K5du3YHHnhg1E2ePDnqJk6cGHWXXnpp1KXPB6lhw4ZFXZcuXaJu7733jrr//d//jTpoK9L3an/zm99EXceOHaPuhRdeiLr0ve5333036uDTaNT2wydRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEVravQFaFlrr7121N18881Rt+WWW0bdvHnzou6GG26Iuvfffz/qJkyYEHU77LBD1PXv3z/qunTpEnUAn8aCBQuiLn2OTH3ta1+Lug022CDq3nrrrVquA6ud66+/Puq6desWdQsXLoy6o446KuoWL14cdbvsskvUVSqVqHv33Xej7sYbb4w64J/bfffdo+7++++PulNOOSXq7rjjjqhbvnx51LV23bt3j7pf/vKXUTdgwICo69y5c9TdfffdUTdr1qyogw4dOkTdz372s6jr06dPLdf5iHHjxkXdhhtuGHX77bdf1J1zzjlRt/nmm0fdCSecEHX19uyzzzbkXPg00p950u+pxx13XC3X+cyS56ujjz56Fdyk9Xj44YejbuzYsVE3f/78Wq4DH+vEE0+MumnTpkVdc3Nz1KXv/T700ENRV2+XXnpp1A0bNizqvv3tb9dyHVjtpK9vOnbsGHVLly6NuvRrLX1PF9oSn0QFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFK2p0RegZZ144olRt+WWW0bdzTffHHVnnXVW1L3++utRV2/PPfdc1G222WZR9+KLL9ZwG4DWZc0112z0FaBVSl8XbLrpplFXrVaj7kc/+lHULVq0KOpSu+22W9Slf47nn38+6v7whz9EHZTokksuiboBAwZEXefOnaMu/TpvK9K/v/T5eeedd4669L/HMcccE3V/+9vfom7FihVRBz/84Q+jbtCgQXU999RTT426q6++Oup69uwZdVOmTIm69LVf+h5dvZ9z07+/CRMm1PVc+DQuv/zyqEv/PadfR416jbP11lt/YrPXXntFjzV16tRar/OZrLfeelGX/rf96le/GnUzZsyIuo4dO0Zdej/ato033jjq9ttvv6i78soro+7999+Puka59dZbo+7f//3fo65v375R17Vr16hbuHBh1EGjpM8tRxxxRF3Pveyyy6LuL3/5S13PhbbEJ1EBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARWtq9AVoWQcccEBdH2/kyJFR9/rrr9f13Hr73ve+F3UXXnhh1J199tk13AYAWB1stNFGde1S77//fl0fr2vXrlF3yimn1PXcmTNn1vXxoC0ZNGhQ1J100klRt2TJkqi76KKLou63v/1t1C1fvjzq6m2dddaJuuOOOy7qfvazn0Xd+uuvH3Wpyy+/POrS/x7Lli2r5ToUZN999426Qw45JOoqlUrUTZkyJer+53/+J+pSL730UtSNGDEi6q655pqoW2ON7P9lXblyZdQ16u8PWsIRRxzR6CusUsnzwQsvvLAKbvLZdejQIeqOOeaYup578MEHR92TTz5Z13Np20499dSoe/HFF6Mu/b1Sa/faa69F3cSJE6PujDPOiLqjjz466q644oqoA4BPyydRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEVravQFaB3ee++9qHv77bdb+Ca12WijjaLu5JNPruu5ffr0qevjAXwalUqlro83ceLEqHvrrbfqei60dum/+bTbYIMNarnOZ3bCCSdE3XbbbRd1r7zyStQNHz486mB10K1bt6ibMmVK1G266aZR17Fjx6j75je/GXUTJkyIukbp27dv1N18881Rt+WWW9Zwm496/fXXo+6YY46JuqlTp0bdsmXLog5SI0aMiLpevXpF3bvvvht1Q4YMibrFixdHXapTp05Rd8YZZ0RdtVqNupUrV0bdgw8+GHWDBw+Ounr//UFbct1110Xd5ZdfXtdzX3vttU9s3nzzzbqeWW+nnHJKQ85NX7/++Mc/buGb0JYccsghUXffffdF3fLly2u5zmrnoYceirrvfe97UTd06NCou+WWW6Kutf9eE4DWxydRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEVravQFaFlLly6Nug4dOkTdMcccE3U333xz1KW22WabqBs3blzUdenSpYbbfFS1Wq3r40Frt9VWW0XdLrvsEnX/+Z//Wct1PrOXXnop6v70pz9F3WOPPRZ1M2fOjLrddtst6jbddNOoS6X3g9LMmTMn6ubOnRt1Xbt2jbrNN9886vbYY4+o+9GPfhR1lUol6i644IKoe+edd6IOVgfDhw+Puq233rqu544ePTrqfve739X13Ea57777om7dddet67nz58+PukMPPTTqZsyYUct1oMVtu+22dX28f/zjH1H3xBNP1PXc9L2tG264Iep23HHHGm7zUVOmTIm6wYMHR93ChQtruQ6sEj//+c+jrlu3bnU998Ybb4y60047LeqWL19ey3XapIcffrgh5y5atCjqVqxY0bIXoU3p1atX1LWVn7PqLf257c4774y6ww47LOrS17CNer6CVPoebKMer97S3xuOGDEi6tLnjNRrr70Wdf3794+69PeGtC4+iQoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAoWlOjL0DLGj16dNQNHDgw6i688MK6dkDrcswxx0TdddddF3Xt27ev5Totrnv37lH3pS99qYVv0rqkf94uXbpE3ZIlS6Ju+fLlUQet3VtvvRV11Wo16s4///yo+7d/+7eoS792r7rqqqi7+uqrow5WBz/5yU+ibtiwYXU99/jjj4+6O+64I+oa9T119913j7p777036jp27Bh16fNp+vx80UUXRV1rf60LqZkzZ0Zd+vPTZpttFnWHHHJIXR9viy22iLpBgwZFXb399re/jbqFCxe28E2gdocddljUnXXWWXU9d9y4cVF34okn1vXckqy77rpRd88990TdypUro27ZsmVR98ADD0QdtGvXrt03vvGNuj7eI488UtfHayvee++9qBs5cmTUpd9jxo8fH3X77bdf1D377LNRB/WWvqdR78dL33Pp27dv1H3rW9+KuvT3kOmfo95/f5tssknU/cd//EfUpX9eWhefRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUrVKtVqsNObhSacSx/BPHHXdc1J122mlRt/vuu9dync9s6tSpUff0009H3be//e2oGz9+fNQdfvjhUQeNMnv27Kjr2bNnC9+EtuSZZ56JulmzZrXwTT7eb37zm6i79957W/gmtBXbb7991D3xxBNRl75uTl/W//nPf466Qw45JOoWL14cdbA6+OMf/xh1++67b9S99dZbUde/f/+oS3+OqbcvfvGLUZd+r+zYsWPUrbFG9v99rVixIuoee+yxqOvVq1fUQWneeeedqEu/xuut3q+ZUn/605+ibv/996/rudASevfuHXV333131G266aZRN3/+/KhLv46efPLJqCtJly5dou6uu+6Kur333jvq3nvvvagbOnRo1F1//fVRB+3atWvXqVOnqHv77bej7qijjoq622+/PepK0759+6ibMmVK1KU/t5111llRN3r06KiD1MYbbxx1r776al3PffPNN6Mufe7beuuta7nOR6Q/t82bNy/qJk+eHHXHH3981DU1NUVdvf/+0vcQS9OgKZNPogIAAAAAAAAAAMpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACK1tToC9A63HTTTVF38803R13nzp1ruc5ntnjx4qg799xzW/gmsHrq2bNnQ8595513ou6FF16Iug8++CDqpk+fHnXHHHNM1HXr1i3qSrPddtvVtau3Qw89NOo6dOjQwjehrZg9e3bUzZw5M+p22223Wq7zEX/961+jLn1dBW3JrFmzom6fffaJui5dukRd+nXZVqTPLxMmTIi6P/zhD1F3/fXXRx3w8b72ta9F3S9+8Yuo22mnnaKuU6dOUZeqVqt1fbwLL7ywro8HjXTGGWdE3aabbhp1r776atQdcsghUffkk09GXUl69+4ddZdccknUfelLX6rlOh/xs5/9LOq8TqMlnHzyyVG3xho+b2JVWLZsWdSdf/75UXfnnXdGXaVSiTqotzfeeCPqbr/99qg78sgjoy79PVW9f5+1YMGCqBs0aFDUzZgxI+rS3wem7zGNGTMm6tZff/2oa2oyx1kdeWUAAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFK2p0Rdg9bJy5cqoe/vtt1v4Jq1LpVJp9BVgtfaDH/wg6q6++uqoW2eddaLuC1/4QtTtscceUdetW7eoa5T0uTn9+1t77bVruQ60Wf369Yu63Xbbra7npq9H9t9//6jr2rVr1C1cuDDqYHXw1FNPNfoKq7XZs2dH3RVXXBF1o0ePruU6QJ1NmTIl6vbee++o23HHHaPukksuiboBAwZEXWru3LlRN2vWrLqeCy1hn332ibqDDz64ruf+13/9V9SV9nWUvO9y6qmnRo81YsSIqOvUqVPUpU466aSou/POO+t6Lnwa1Wo16tLfe7FqTJ06NeoWLFgQdem/A2iUefPmNfoK/58uvvjiqPvFL34RdUuWLKnlOp/ZpEmTou7Pf/5z1PXq1Svqli9fHnW0Lj6JCgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAAChaU6MvAG3BzJkzG30FqIuXXnop6nr27FnXc08++eSoGzhwYNRttdVWUfeFL3wh6hqlUqlE3QUXXBB1o0ePjrr072/zzTePuq233jrq0n9X77//ftS99957UXf33XdHHayzzjpRN2rUqKirVqtRN2fOnKjbbLPNoq53795R99Of/jTqhgwZEnWwOrjmmmui7s0332zhm3y8b3/721HXv3//up67cOHCqOvTp09dHw9o2x5//PGo22mnnVr4Jh/viiuuiDrPaawOJk2aFHUdOnSIuvT9oxtvvDHqWrv0/aMRI0ZE3X777feJzYYbbhg9VuqJJ56IugsvvDDqxo0bV8t1AP6p7bbbLuo6derUwjeBVePcc8+NugMOOCDq6v17r169etX18RrlW9/6VtT169cv6saMGRN1ixYtijpaF59EBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABStqdEXgEZYb7316vp4vXr1quvjQaMcddRRUfenP/0p6tZee+2o6927d9SV5s4774y6Sy65JOqWLFkSdY888khdO2grDjvssKjbdttto27GjBlRd+CBB0bd7bffHnX77bdf1HlupkQrVqyIuvTrLdWxY8eoGzRoUF3PTb+XDxs2LOoWLlxYy3WAwuyyyy5R16VLl6irVCpRN3369KhLf86C1UGnTp2ibuXKlVH30ksvRV21Wo26TTbZJOq+8pWvRN2AAQOi7rjjjou6eltjjU/+f9vT/xaPPvpo1J177rlRN2nSpKgDaCnp+2Dt27dv4ZvAqpH+3ub++++Pun/5l3+JuvTnp4MOOijqxo8fH3UPPvhg1KWvI3fccceoO/roo6MutXz58ro+Hq2LT6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAitbU6AtAI+y88851fbzHHnusro8HjfK3v/0t6i699NKoO/PMM6Nu7bXXjrpG+eCDD6LuxRdfjLpLLrkk6n7zm99EHbBq9OrVq66P9+Mf/zjqFi1aFHUzZ86Muv322y/qdtttt6jr169f1P3+97+POijReuutF3V77LFH1M2fPz/qmpubo2727NlRB/BpfPnLX466jh07Rl21Wo26CRMmRB20JStXroy69Oto3333jbp58+ZFXapSqURd+udIu1T6Guz555//xObKK6+MHiv9Oeu1116LOmhLFi9eHHVrrJF93sSwYcOi7vbbb4+6tmLNNdeMunPPPbeu3cSJE6Nu9OjRUQet3fDhw6Nuk002ibqjjz66lut8xP777x916XvJ6evXervmmmuiLn2uYvXkk6gAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAojU1+gLQCEuXLq3r473wwgt1fTxo7c4999yo++1vfxt1hx56aNT17Nkz6lIvvfRS1N19991RN3PmzFquA7Ry3/zmN6OuUqlE3WabbVbLdT7zuWmXqvefA6jdW2+9FXVLlixp4ZsAJdppp52i7oILLqjruW+88UbUXXXVVXU9F1YHAwYMqGuX/mzUtWvXqEstW7Ys6h588MG6nnvTTTdF3d///veoe+6552q5DhC65pprom7gwIFR17dv36jbd999o+6hhx6Kukbp3bt31KXv7X/ve9+ra5f+94XSnH322VE3fvz4qPv+978fdf/6r/8addVqNepSL7/8ctT9+7//e9Q9+uijUTd//vyoY/Xkk6gAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAolWq1Wq1IQdXKo04ljZuo402irpnn3026tZbb72o69evX9Q98MADUQcAtD7nn39+1J1zzjlR9/7770fdFVdcEXX77rtv1O2+++5R99Zbb0Vd9+7doy7980KJ2rdvH3U9evSIuiVLlkTda6+9FnUAn8Z1110Xdccff3xdz01fq1144YV1PRdKtOWWW0Zdp06d6nruihUrou7JJ5+s67lA27bjjjtG3cSJE6Nu3XXXjbr091Tp71NnzJgRdb179466Xr16Rd3DDz8cdUOGDIm6J554IuqAVaNDhw5RN2bMmKhbf/31o+6RRx6Jul//+tdR98wzz0QdrUuDpkw+iQoAAAAAAAAAACibERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAoWqVarVYbcnCl0ohjaeN69uwZdbNnz67ruRtssEHUvf3223U9FwBYdTbbbLOomzZtWtT16NEj6tLXzenL+pUrV0bdD37wg6gbPXp01AEAq7cddtgh6h5//PEWvsnHGzJkSNRdc801LXwTAKAt2nHHHaPupz/9adQdfPDBUZe+L/TKK69E3ZgxY6Lu2muvjbp58+ZF3eLFi6MOAP6vBk2ZfBIVAAAAAAAAAABQNiMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAULRKtVqtNuTgSqURx9LG9ezZM+pmz54ddQ8//HDU9e3bN+pWrlwZdQDA6mv77bePumuuuSbq9t5776hbuHBh1F188cVRN3r06KgDAMowcuTIqDvjjDNa+CYfr6mpqSHnAgAAAPXXoCmTT6ICAAAAAAAAAADKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAitbU6AtAa7Z48eKoW7lyZQvfBABYXTz99NNRt++++7bwTQAA6mfWrFlRN3fu3Kjr3r171I0ZMybqAAAAAGrlk6gAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAojU1+gLQmr366quNvgIAAABAw910001RN2PGjKi7/PLLo+6HP/xh1AEAAADUyidRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEWrVKvVakMOrlQacSwAAAAAAAAAANBKNWjK5JOoAAAAAAAAAACAshlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACK1tSog6vVaqOOBgAAAAAAAAAA+H/5JCoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACKZkQFAAAAAAAAAAAUzYgKAAAAAAAAAAAomhEVAAAAAAAAAABQNCMqAAAAAAAAAACgaEZUAAAAAAAAAABA0YyoAAAAAAAAAACAohlRAQAAAAAAAAAARTOiAgAAAAAAAAAAimZEBQAAAAAAAAAAFM2ICgAAAAAAAAAAKJoRFQAAAAAAAAAAUDQjKgAAAAAAAAAAoGhGVAAAAAAAAAAAQNGMqAAAAAAAAAAAgKIZUQEAAAAAAAAAAEUzogIAAAAAAAAAAIpmRAUAAAAAAAAAABTNiAoAAAAAAAAAACiaERUAAAAAAAAAAFA0IyoAAAAAAAAAAKBoRlQAAAAAAAAAAEDRjKgAAAAAAAAAAICiGVEBAAAAAAAAAABFM6ICAAAAAAAAAACK9v8AW/mbULCm+TsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 3000x900 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAACVEAAAKICAYAAABzbCh9AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAuIwAALiMBeKU/dgAAadBJREFUeJzs3He4nWWd7/+9dk2yk+z0AgkhhZAQCE0CoUgvCqJIszKiHHHmqGdsYxvrGY8zjmMZB7gQVGREQEbpCBgkAgKhBUioIQVI73X3tdfv7/kdz5VPZMHeyfN6/f2+1l57ZT33up97fbNLlUqlUgMAAAAAAAAAAFBQtb39BAAAAAAAAAAAAHqTISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAotPre+sGlUqm3fjQAAAAAAAAAANAHVSqVXvm5/hIVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaPW9/QR2plQqRV2lUnmTnwmwO7BmAAAAAFANzpmAXWHNAPY01jVgV9TWZn/Dqaen501+Jm+Mv0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUWqlSqVR65QeXSr3xYwEAAAAAAAAAgD6ql0aZ/CUqAAAAAAAAAACg2AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLT63n4C7F7q6uqirr4+e2uVSqWoK5fLUZfq6emJukqlUtXHAwAAAAAAgGpKv29Lu1T6PVraAW+NdC2orc3+Jk86Q5B26c/t7u6OunTWIO2saXs2f4kKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAotPrefgK8uRoaGqJu+vTpUXfRRRdF3dvf/vaoGz16dNQ1NzdHXW1tNhfY0dERda+++mrU3XrrrVF38803R92SJUuirrOzM+qgt5RKpap26TVeV1dX1cerr88+LtPfo7GxsaqPl64F7e3tVX28SqUSdbCnqPaa0b9//6hL14z0mkz3QW1tbVFXLpejzpoBAACQ3Vv269cveqyhQ4dG3bBhw6IuvU/duHFj1G3YsCHqtm/fHnXd3d1R5/6T3pSeTQ8aNCjq9ttvv6g79NBDo27y5MlR19LSEnWLFy+OunvuuSfqXnzxxajz/Rh7ivR7oPS78mnTpkXd2WefHXVHHXVU1E2ZMiXq0rUvXUtbW1ujbsWKFVF3yy23RN21114bdatXr4669Iydt4a/RAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRafW8/Af46tbXZ/Nu4ceOi7uKLL466s88+O+pGjhwZdY2NjVGX/r6lUinqBg4cGHVDhw6NugMOOCDqzjjjjKj7+te/HnWPPPLITpvOzs7osaCmJr/Wmpqaoi5dC2bOnBl16bU2derUqJswYULUDRkyJOoGDRoUdQ0NDVHX1tYWdc8++2zUXXPNNVE3b968qNu6dWvUVSqVqIM3Q11dXdS1tLTstJk2bVr0WKeffnrUHX/88VE3fPjwqOvu7o66FStWRN3NN98cdXfccUfUrV+/PurK5XLUAQAAvBXS+8rBgwdH3QknnLDT5vzzz48eKz0ra25ujrpt27ZFXXIuXVNTU3PDDTdEXXq2lT4/Z1Hsivr67KvS9PuiWbNmRd0HPvCBqj7eiBEjoi49m06/b9u+fXvUTZkyJeq++93vRt1rr70WdT09PVEH1ZZeQ6NGjYq6Sy65JOrOOeecqJs8eXLUDRgwIOrS/VL6uqTS/Vf6feW+++4bdelnx09+8pOo27x5c9Tx1vCXqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEKr7+0nwF+ntjabf2tsbIy69vb2qFu/fn3UdXV1RV1bW1vUdXR0RF2pVIq6AQMGRN3QoUOr2h1++OFR953vfCfqLr300p02L7zwQvRYPT09UcfuqaGhIepGjBgRdSeffHLUXXDBBVF38MEHR11LS0vUpWtfupZWW7pWdXZ2Rl26pj3zzDNV7bZt2xZ1lUol6mBXpNf5/vvvH3Uf//jHd9qccsop0WONHj066qq9BpXL5ajbd999o+6II46IuhNPPDHqvvKVr0TdihUroi79feHNkH6W19XVVbVLf266t+/u7o669LO8r3/mp69ffX12VJJ26etc7X8PqLZ075KuaU1NTVGX3s8OHDgw6lJbt26NuvRsK73Gnc/AWyddX6ZMmRJ1X/3qV6Pu6KOP3mmT7jPWrVsXdUuXLo26dL+UruHp2pz+3LRjz5ZeH+n3Nscdd1zUpWfd6eMNGzYs6qp9v1jt+7v0zP7UU0+Nuttvvz3qli9fHnX2VvSW9Pz6yCOPjLpzzz036vbbb7+oSz/L0/vA9FpL15b07LfaZ3RDhgyJuve///1Rd9ddd0Xd/Pnzo86a9tbwl6gAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCq+/tJ8Bfp6enJ+pWr14ddbfddlvUPfnkk1G3ffv2qFu6dGlVH69cLkddXV1d1M2cOTPqvvnNb0bdQQcdFHXTp0+PulmzZu20WbRoUfRYnZ2dUUffkr6X995776i7+OKLo+7DH/5w1I0dOzbq0t8jXfu6urqibtu2bVHX1tYWde3t7VFXKpWiLrVly5aoS59f+u8Bb4aGhoaoSz+jP//5z0fdscceu9Omtjb7/wcLFiyIukceeSTqli1bFnXpfmnGjBlRd95550XdGWecEXXp2vyZz3wm6jZv3hx1UFOTf/amn4EtLS1RN3Xq1Kjbf//9o27o0KFRt379+qjbtGlT1KXX77p166Iu3dOlGhsbo27cuHFRd8wxx0Tdhg0bou6ee+6Juueeey7q0j0dpNJraMSIEVF30kknRd0555wTddOmTYu6YcOGRV0q3Vv96U9/irqf//znUTd//vyoS9eCSqUSdbAn6devX9Ql94E1NTU13//+96NuzJgxUffSSy/ttLn22mujx3rqqaeiLt1HvvOd74y69LMjPVNLz/WtaXu29H11yCGHRN1FF10Ude95z3uiLt0L1ddnX71W+6w7PSdJ79vSdWPUqFFRN3z48KhLvveqqampuffee6MOekt6FpWuBa2trVGXfvamj5feF73++utR9/LLL0fdmjVrom78+PFRl+5x0rUv/f7zgAMOiLpnnnkm6qp9psZf5i9RAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhVbf20+Av05PT0/Ubd++PeqefvrpqHvmmWeirqurK+q6u7ujrtrq67O3/tKlS6Nux44dUVdbm80t1tXVRV36e7Dnampqirqjjjoq6s4666yoGz16dNSl7/n0GnryySej7rHHHou6xYsXR93atWujLr12R40aFXUHH3xw1KVr6bp166Kuo6Mj6mBXpOvByJEjo+6d73xn1I0dOzbqks/8O+64I3qsG2+8Meo2bNgQdeVyOeoqlUrU3XnnnVH36KOPRt0Pf/jDqDv11FOj7uijj466u+++O+rSfTN7tlKpFHUDBgyIumnTpkXdhRdeGHUnnHBC1A0ZMiTq0t+3s7Mz6tLrKF3r0+eXPl5639vS0hJ1zc3NUffcc89F3UMPPRR1UG3pNTRmzJio+9rXvhZ17373u6MuvZ9ta2uLui1btkRdumfq169f1J1xxhlRN2XKlKj75Cc/GXUvvPBC1KV7SdgdpNfl7Nmzo+7HP/5x1I0YMSLqfv/730fdt7/97Z02q1atih4r3VcddNBBUbfXXntF3aZNm6Ju48aNUZfuS9M1nL4lPTOdOXNm1H31q1+NuhNPPDHq0vvAVPr9WHqdz5s3L+puv/32qFu9enXUnXPOOVH3kY98JOoaGxujLj07T/e60FvS722WLVsWdbfddlvUTZ06NerS+4knnngi6l5++eWoS78P7N+/f9Sl92Nnnnlm1KV7q3RPkt6PpT+Xt4ZPGAAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNDqe/sJ8OYql8tR197e/iY/k7+sUqlEXalUirra2mwucPjw4VH3oQ99KOoOO+ywqEuf35YtW6Luueee22nT09MTPRZ9S/qeb2xsjLoRI0ZEXXNzc9Sla0tHR0fUzZs3L+quuuqqqFu2bFnUNTQ0RN2gQYOibvz48VE3YcKEqBsyZEjUbdq0KerWrVsXdd3d3VGXruGwK5qamqIufd/PnTu3at2CBQuix0o/x9NrrdrStTl97R5++OGoO/PMM6Pu/PPPj7o//vGPUddb+1x2T3V1dVE3evToqJs8eXLUpWtfV1dXVbv0XiHt0j1s+nitra1Rl+7Vhg0bFnXpHmfp0qVR9+qrr0Zd+u8GqQEDBkTdJz/5yag777zzoq6zszPqfve730Xd9ddfH3Wvv/561NXXZ8eh06ZNi7pPfepTUZfeB5588slRt2jRoqhL79+hN6V7sEmTJkXdN7/5zagbNWpU1N1yyy1R97WvfS3q0vOZxNChQ6PuggsuiLqpU6dG3W9+85uoW7FiRdSl+yBnUbun9H160UUXRd3RRx8ddf3794+69P5k8+bNUTd//vyoS6+j9NxlzZo1UZd+T3XUUUdV9fFS6XWefnZAb0nXlsWLF0dd+v1YKj0jTu/v0jOhdG1O932XXHJJ1A0ePDjqUhs3boy6dC/k+/y+xV+iAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACq2+t58AfUOpVIq62tps7q6uri7qGhsbo27o0KFRN3v27Ki74IILou7444+PugEDBkRdW1tb1P3qV7+KuhdeeGGnTblcjh6LvqVSqURdZ2dn1C1ZsiTqXn755ahraGiIuvT9t2PHjqibOHFi1I0bNy7qjjzyyKibPn161I0dOzbq0rWvp6cn6latWhV1a9asibply5ZFXXt7e9Sl79P0fc/uKf33XbduXdT99re/jbp077Jhw4adNh0dHdFjpddub0n/LVpbW6PugQceiLozzzwz6mbOnBl1LS0tUZeuVezZ0vd9V1dX1G3ZsiXq5s+fH3UPP/xw1KV7tcWLF0dden2k9zHp+pfuEUeMGBF13/rWt6Ju3333jbqVK1dG3TXXXBN1q1evjjr3bqTSM5dDDz006s4///yoS6/xyy+/POquvvrqqEv2aTU1NTXd3d1Rl56BrV27NupOOOGEqEvvK0ePHh116e8Bu4N0XUvPatPr7dVXX426H/3oR1G3cePGqEv2pv37948e6/3vf3/UnXXWWVH30ksvRd1dd90VdVu3bo26vn4fzV+Wfhal+/rx48dX9eem9zHpmemcOXOi7qabboq6p59+Ouq2bdsWdakhQ4ZE3bRp06IuXcPTvZr7J/YU6WdbejaTnk2na2Tapd9nTZgwIerSPcnf/M3fRN3kyZOjLl2r0tf5sccei7r0+1l7ob7FX6ICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKrb63nwBvrsbGxqgbNWpU1B100EFRd8QRR0TdjBkzom7mzJlRN3bs2Kjr169f1JVKpahrb2+PuhtuuCHqfvGLX0Tdtm3bdtpUKpXosdg9dXR0RN0TTzwRdf/5n/8Zde94xzuibuLEiVE3cuTIqDvvvPOibsSIEVXtmpqaoq6+vnc+VgcOHBh1//N//s+oS9fcf/u3f4u6+fPnR11nZ2fUWdd2T+m/244dO6KutbW1qj/X++r/Vi6Xo27RokVVfbx0bR46dGjUrVmzJurYs6XXeFdXV9QtXrw46rZs2RJ1a9eujbqNGzdGXV9fI+vq6qJu+PDhUZfef6a/x29+85uoe+yxx6Iu3bNDqn///lF34YUXRt2QIUOi7tFHH4269Ewj/YxO9xDpNV5bm/2f0vTnjhkzJurSM7p0re/p6Yk62B2k12V6fpSe6S5cuDDqVq1aFXXpdZms4+eff370WJ/97Gejrq2tLep+8pOfRN0rr7wSden+mj1betaT3meln72rV6+Ouj/84Q9Rd//990fda6+9FnXpdZnucdK1L937HXrooVGX3t+l96lLliyJuu7u7qiDvq7a13hDQ0PUpd+pf/jDH466d77znVG33377Rd2gQYOirtr3d+l96n333Rd16f2d7yf6Fn+JCgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLT63n4C/HelUinqGhoaou7www+Pus985jNRd9RRR0Xd0KFDo66xsTHq6uur+1atVCpR19PTE3WbN2+OukceeSTq1q1bF3Xp82PPVS6Xo27jxo1R96c//SnqXnvttag79thjo+7AAw+MuhkzZkRdv379oq6rqyvq0mst/ffo7OyMulRzc3PUDRo0KOpOPfXUqBs2bFjUfelLX4q6Z555Juqq/frRt6Sf0WnHmy+9JtN/s7q6uqjr7u6OOtgV6ftq/fr1UZfeJ7S2tkZdunfp62tkunf5l3/5l6hL9yRLliyJumuuuSbqduzYEXWQSs+ERo0aFXWzZs2KuvS9fP3110fdmjVroq6vf5YPHjw46tL71HRtfvbZZ6Our79+sCvS62PlypVRl+6Z0ut3//33j7pXX3016k444YSdNl/72teixxowYEDUXX755VH38MMPR117e3vUsWdLr93Vq1dHXfo+ve6666Juw4YNUZfe33V0dERdekZcbel5SnpmP27cuDfydP4v6fvgqaeeirreep2h2tL7wPQaHz9+fNR96lOfirr3vve9UTd8+PCoq/Z3/tX+/m779u1Rl37v2tfP6PjL/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0Op7+wkURalUirq6urqoGzlyZNR96EMfirrjjjsu6oYPHx51tbXZfF76ulQqlajr7u6OunK5HHXp8xsxYkTUffrTn466V155Jeoee+yxnTadnZ3RY7FnS9/zGzdujLq2traoW79+fdQtWrQo6pYtWxZ1Bx10UNQNGDAg6lpbW6PumWeeibqXX3456tLPhPHjx0fdWWedFXUzZ86MulmzZkXdl7/85aj75Cc/GXWrVq2KuvSzA3hjGhsbo66hoSHq0s+OHTt2RB3sip6enqhL90LV/rl9/bMtvQ88/fTTo+6YY46JuvSe5ytf+UrULV26NOr6+r8Hu590/7/XXntFXf/+/aMuvc966qmnoq6rqyvqekt61rP33ntH3ZgxY6Ju27ZtUffiiy9GXfrZAbuD9Ez3gQceiLrFixdH3eTJk6PuG9/4RtQtWbIk6k455ZSdNukafuONN0bdz3/+86hzn8WbId0bpPvwan+vlOqt/X/6+w4cODDq3vOe90RdenaeruEPPvhg1K1YsSLqoGjStWDYsGFRN2nSpKjr169f1KU6Ojqirr29Perq67Nxl/QMe/To0VG33377Rd2cOXOirrc+2/jL/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0Op7+wnw35VKpairq6uLutbW1qjbtGlT1NXXZ2+Z9PfYvHlz1L366qtR99xzz0VdV1dX1B122GFRd8QRR0Td9OnTo+5zn/tc1F1yySU7bTZu3Bg9VqVSiTp2T+m/b7lcjrq2traoW7VqVdR1dHRE3Zo1a6JuyZIlUTd48OCq/txnn3026jZs2BB13d3dUVdbm81E//GPf4y6f/qnf4q64447LuqOPfbYqna/+93voi59/dg9pXuNVHIdpT8z7dK1udpdqqmpKepOOeWUqEv3kc8//3zUbd++PepgV6TXUU9PT1Ufb08xZsyYqPvyl78cdel97y233BJ1c+bMiTp7CPq6/v37R93rr78edeln77p166Kur0v3JCeeeGLUNTQ0RN2CBQuibu3atVEHe5L0PCpd1370ox9FXbonmTlzZtSlZ8TJOvSHP/wheqyf/OQnUZee/0Nv6q3zj2qr9vlRuvc788wzo2727NlRl545b9myJepuvvnmqEu/e4A9RbW/v1u9enXUPfDAA1GXPr+BAwdG3cqVK6Nu2bJlUXfGGWdE3YwZM6Kuubk56qZMmRJ16f0nfYu/RAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRafW8/Af67np6eqNu0aVPUXXfddVH34osvRl1LS0vUbdiwIeqeffbZqFu/fn3Utba2Rl1q3333jbp///d/j7rDDz886o4++uioO+igg3baPPjgg9FjlcvlqGPPVqlUoi59v3R2dkbdli1boq65uTnqduzYEXXd3d1R99prr0Xd6tWroy59fulnQqlUirqFCxdG3dVXXx116Zo2cODAqDv55JOj7o477oi69N+Xt0ZtbTa739TUFHX9+/ePuqFDh0bd3nvvvdMmfW6NjY1R197eHnXpWrp8+fKoS9egiRMnRt35558fdV1dXVF37733VvXx4M2Q7pn2FOm69uEPfzjqpk6dGnUbN26Muu9973tRl65/0Nel9x1333131KVnM9u2bYu63loj0/ui9L7ytNNOi7r097399tujLt37QRGl18fjjz8edS+88ELUpWfE/fr1i7rNmzfvtEnvi1auXBl16RkT8P+W7jXS86P0+7Zjjjkm6v7+7/++qj83XTfStTQ9Y0/PEBsaGqIu/T3Srtp73aKdL/DXS9+jq1atirpf/epXUZfeV6bPr6OjI+rGjh0bdbNmzYq6dA2vr8/GZ9K1Kv259C3+EhUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBo9b39BPjvSqVS1HV0dETdSy+9VNWup6cn6srlclW7SqUSdenrV1ubzQ8uWbIk6v74xz9G3SGHHBJ1gwcPjrqTTjppp82f//zn6LHSfwt4MzQ1NUXduHHjom7ChAlRt2bNmqhbt25d1LW3t0ddupama1/adXV1Rd2yZcuibsuWLVE3aNCgqJs8eXLU1dXVRR1vjfSzd8SIEVF3zDHHRN20adOiLv3sHT169E6b+vps6zxgwICoS6/dzZs3R90LL7wQdcuXL4+697znPVGXrs1r166NupdffjnqGhoaoq67uzvq0r1Q+p6v9hoOb4b0/bzffvtF3Sc+8Ymq/twf//jHUZeuf643+rr0s+iVV16Juk2bNkVduq9P73f6+rWW7PtqampqJk2aFHVbt26Nurlz50Zder8IRZSe6Q4bNizqhg8fHnXpPUVbW1vUJecz6RmONQPeuHRtSb+3mTJlStS9+93vrmqX/tz0bLWzszPq0u8rjzvuuKgbM2ZM1KV7sG3btlW1Sz8TduzYEXXpZ4f1/s2XnlWkqn1fVO3vgVavXh116ZluurYMHDgw6o488sioO+CAA6IufX7pmpa+Lunj9fX76KLxl6gAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCq+/tJ7C7K5VKUVdfn73UjY2NUVepVKKuu7u7ql36c9Ou2qr9/Kr9OqfS91Vzc3PVHgt2Rfq+Ste08ePHR93RRx8ddYccckjUPfnkk1E3b968qOvra2RPT0/UdXR0RF36e9TWZjPbLS0tUdevX7+o27ZtW9TxxjQ1NUXde97znqh7//vfH3UbNmyIupdeeinq7r777p02XV1d0WOl3aBBg6Ju2LBhUXfYYYdF3RlnnBF1e+21V9SlXn311ahLX5fhw4dH3aZNm6Kuvb096tLPwHR/WC6Xo663PjvYs6WfqV/4wheibvTo0VG3YMGCqLv22mujrrOzM+qgr0vX+vQza/Xq1VG3p3wWpfcdb3/726Nu8ODBUZfeLy5fvjzqoIjSPXa61/jYxz4WdVOnTo26xYsXR126txo7duxOm/SMJF37oIjS6yM9dznyyCOj7pJLLom6WbNmRV36/BoaGqIule790rP4GTNmRF16f7d+/fqoe+WVV6raLVq0KOoee+yxqHv99dejrrW1Ner6+p69N9TV1UVd+l1+tc8G0+9tqv1vW+3HS/dBxx57bNSlZ1EjR46MutTGjRujbu7cuVGXft9G32KHDQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFFp9bz+B3V2pVIq6IUOGRN3UqVOjrrY2m39bsmRJ1G3atCnqOjo6oq5cLkddtaX/Ho2NjVE3adKkqDv99NOjrr4+u+S6urqi7vXXX99pU6lUoseCN0N6rR144IFRd8opp0Td6NGjo2779u1RN2jQoKirq6uLuu7u7qir9vWb/ntMnDgx6tLPtvT32Lp1a9R1dnZGHW9M+pk6ePDgqEuv3xEjRkTdddddF3W33XZb1G3bti3qEulrN2DAgKhL18gTTzwx6tJrN933rVy5MurS/eHb3/72qEtfv2eeeSbq1q9fH3XpGpSufT09PVV9PKipydehGTNmRN2ZZ54Zden18b3vfS/q0uvS9UHRpO/59L5jT9HU1BR1F1xwQdSla+ntt98edTt27Ig6KKL03OWss86KuvSsdu3atVF3+eWXR136/PbZZ5+dNukZU2+dw0NvSr9nGTt2bNS9973vjbqLL7446pJrvKampqZ///5R19DQEHXp3iXdS6bfQ6Zng+nzS7sxY8ZE3bRp06Ju8+bNUbd48eKoGz9+fNTdeeedUffcc89FXW9991Bt1fy+d9SoUdFj7b333lGXXhtr1qyJuvR7qvb29qhL9wbp2pKuaR/84Aej7sILL4y6dA1P90xtbW1R97vf/S7qnnzyyaizV9s9+UtUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodX39hPY3dXWZnNoY8eOjbrzzjsv6lpaWqJu/vz5UXfvvfdG3erVq6OutbU16srlctSlr3P//v2jbsaMGVH3xS9+MeoOOeSQqEt/j/Xr10fdvHnzdtr09PREjwVvhsbGxqgbN25cVbt0jUzX5pEjR0bda6+9FnVdXV1Rl16/dXV1UTd69Oio++AHPxh1gwYNirp0rX/kkUeirrOzM+p4Y0qlUtT169cv6pqamqIufb9UKpWoS59fe3v7Tpv0WkvXjCOOOCLq0msy3Y+8/vrrUXfXXXdFXbr2HXnkkVGX7tPSNSh9Lz/zzDNRt27duqjr6OiIuvS9DLti4MCBUfeVr3ylqo/35z//Oermzp0bdelnAkBNTU3N/vvvH3UHHXRQ1G3dujXq/vCHP0Sd8xmKKL2HmjZtWtRddNFFUdfQ0BB1V111VdQ9//zzUfd3f/d3UZfcAyxfvjx6LPsl9iTp9yeDBw+OurPOOivqPvGJT0RdejZdX5999Zqukem5RrrXSM7Aamqqf/5R7bPG9LuHanfDhw+PugkTJkTd0KFDoy69PvYU6Vlycg9w7rnnRo91wAEHRF167a5ataqq3fbt26MuPTOdNGlS1KVnuukamX6Xn64Z6fdF6ZlVuj/cvHlz1Dn73T0Va8UFAAAAAAAAAAD4/zFEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqvv7Sewu6tUKlFXV1cXdZMmTYq6mTNnRt3s2bOj7pBDDom6OXPmRN2KFSuirr4+ewuOGTMm6o455pioO+2006Ju/PjxUZf+Hu3t7VH3s5/9LOpeeOGFnTY9PT3RY8GuSNe+tra2qOvs7Iy6AQMGRF3//v2jbp999om6gw8+OOrWrl0bdelnQrq2pL/HRz/60ag744wzoq62NpvFfu2116LuzjvvjLr0/cIbk17nW7ZsibqHH3446oYNGxZ1Z599dtSle5z169fvtBk3blz0WFOnTo269NrdsWNH1N19991R9+///u9Rt3z58qhLrVy5MupOOeWUqBs1alTUpa9zulYl75Wamvwagl2Rfvam94tHH3101HV0dETd97///ajbtGlT1AHU1NTUNDQ0RN173/veqGtubo66Rx55JOqWLFkSdVBE6fnMmWeeGXUTJ06Munnz5kXdQw89FHXHHXdc1KVn+8nZ+aOPPho9Vnd3d9TB7iA9Cz3ooIOiLj0LTc8N0j1JqVSqapd+x7Nx48aoS7/nS89q0/OU9PUbNGhQ1E2ZMiXqhg8fHnXpdw/pv1vy/V1NTf596p7yXV96rpGeESd7iPPPPz96rJEjR0ZdqqurK+rS7zvSNTK9hpqamqIu/T4rvTZS6Xfq9957b9R997vfjboXX3wx6srlctSxe/KXqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEKr7+0nsLvr6emJuhUrVkTdsmXLom727NlRN2bMmKgbP3581L3rXe+Kuo6Ojqirq6uLun79+kVd//79o66+vrpv/e3bt0fdDTfcEHW/+MUvom7r1q07bSqVSvRYsCvS91V7e3vUPfjgg1H30Y9+NOqGDh0adena9z/+x/+IumnTpkXdxo0bo26vvfaKukMPPTTqJkyYEHVNTU1Rl6xBNTU1NT/72c+i7plnnom6crkcdbwx6XVe7c/A9PEOOOCAqEvf9/vvv/9OmyFDhkSPtXnz5qi77777ou7mm2+OukcffTTq0ms3vdbS/dxTTz0Vdek+LX0PrF+/Puo2bNgQdelnW1dXV9TZq7ErBg4cGHXp3mXQoEFR9+c//znqHnvssahL76MBamry+7tzzz036tI9zk033RR16RkY7ElKpVLUDRgwIOrSvX36c5csWRJ16Rn7pz/96ahL15crrrhip82qVauix3I/we4gvXbT74GOPfbYqEvPfhsaGqKutra6f5eiu7s76tLvFy+//PKou+WWW6IuXYfS3yO9D0zPmebOnRt16fsvfR+k79P0565duzbq0td5T/lcSM8HW1paqtLU1ORnLul7tNrS91TaVVu117Trrrsu6n75y19GXTqDkf4e7Nn8JSoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQ6nv7CezuKpVK1G3cuDHqrr766qgbPXp01J188slRN3jw4KgbNmxY1JVKpahLX79U+nhdXV1Rt3Tp0qj7+c9/HnW//vWvo27t2rVR19PTE3XQW7q7u6PuxRdfjLobbrgh6j772c9G3cCBA6Nu0qRJUbfPPvtEXaq2Npt1Trt0jdy6dWvUXX/99VGXrpFtbW1RR99SLpejbvny5VF37bXXRl3//v2jbuTIkVFXX7/zbXH6ubt+/fqo27ZtW9S1t7dHXfpv0Vv7r/R1efrpp6Mu/YzZtGlT1G3evDnq0n8P+zR2RfpZfuCBB0bdqaeeGnXpdXTVVVdFXbqHAKipqampq6uLutmzZ0fd3nvvHXXpnuT++++POp/58P/W1NQUdQ0NDVGXrhvveMc7ou5d73pX1DU2NkbdNddcE3U33XTTTpvOzs7osWBPkl5rLS0tUZfeZ6XSz/z03ODxxx+Pussuuyzq7rvvvqjbvn171KXnTNWW3qd2dHREXfp9Zaraj1e0vWR6jrhly5aoW7BgwU6b9DvX9LvydD9S7TUolb6n0u/K0/unefPmRV36Pd8DDzwQdRs2bIi6ol1rvDH+EhUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBo9b39BIqiu7s76l544YWo+8xnPhN1xx9/fNSdeuqpUXfooYdG3ciRI6OuVCpFXWtra9Slr98999wTdffdd1/Uvf7661HX1tYWdZVKJeqgr0vfy9u3b4+6q6++Oup6enqi7m//9m+jLl3TGhoaoi6V/h7pGrlo0aKou+yyy6Lu1ltvjbrNmzdHnbVvz1Yul6Nu27ZtVe3WrVsXdQnv0b8sfV26urqibu3atVE3f/78qKv2Z1G6r4dd0dzcHHUXX3xx1A0ePDjqFi5cGHUPP/xw1KVrPUBNTU3NwIEDo+6iiy6Kuvr67JjzoYceirqVK1dGHRRRusdOzwOeeuqpqHvb294WdaNHj466jRs3Rt3Pf/7zqLviiiuibsuWLVEHRZOeG7zyyitR99JLL0Xd3nvvHXXpGdPNN98cdTfddFPUpd8/dXZ2Rl3RVPs8z/ngG5O+funZ7x133LHTJr023ve+90XdjBkzoi6930nXvvQ1efLJJ6PugQceiLp58+ZF3YoVK6Iu/T4rfV1ck7wZ/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0EqVSqXSKz+4VOqNH8sb1Nf/3Xrp7Qy8RWprs9nflpaWqJs5c2bUnX/++VF3xBFHRF1TU1PUrVy5MuruueeeqPuv//qvqFuzZk3UdXd3Rx3ArkjX+rq6uqp2XV1dUdfT0xN19qXU1OTv5/333z/qbrjhhqjbZ599ou773/9+1P3oRz+Kuh07dkQdb430/t16RbWla9/UqVOj7rbbbou6UaNGRd0ll1xS1Z/b2dkZdVBE6XowevToqDvjjDOibu+99466O+64I+oWLVoUda2trVHnsxf+snT/2tjYGHXpGeyAAQOiLr3faWtrizpnq/DWSNeWdN+SrkHlcjnq0rPGanewO+itfbO/RAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRafW8/AXYvlUqlt58CUGA9PT1Rt2nTpqj705/+VNUuVSqVqvp4KWs4sDtI1/q06+rqeiNPB96QhoaGqDv44IOjbsiQIVG3evXqqHvkkUeirru7O+roW+z96C319dlxY7r2DRo0KOpWrlwZdUuXLo26dK8B/L+l19GqVaui7he/+MUbeTpAH5fuXzs6Oqrabd26NeqA3VO6tpTL5ahra2t7I08H2A34S1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAECh1ff2EwCAoqlUKr39FACAt0CpVIq6tra2qHvhhRei7plnnom6RYsWRV25XI46gJqa/H5n06ZNUffEE09E3dy5c6NuyZIlUWftAwAAgOLxl6gAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCK1UqlUqv/OBSqTd+LADAmyrd4/TSFgyAt1Btbfb/lhobG6Ouf//+Udfe3h51nZ2dUdfT0xN1PtuAXdHQ0BB16VpaLper2lnTdk/uxwAAAHpHte/Heuu+zV+iAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoZUqlUqlV35wqdQbPxYAAAAAAAAAAOijemmUyV+iAgAAAAAAAAAAis0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACq2+t58AQF9WKpWirlKpvMnPhJqa/N+jr/+7pc+vr0tfP9fHG9PX389A32LNAAAA6B3ux4A9jXWN1J7yvVfKe37P5i9RAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhVaqVCqVXvnBpVJv/FgAdmO1tdnsb/oZk3bpR2W1u1QvfZQDAAAAAACwh0q/R6urq6tq19PTE3Xlcrmqj0ff0lvff/pLVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHV9/YTAID6+uzjaNSoUVF39NFHR92+++4bdevWrYu6F154IepeffXVqNuyZUvUdXV1RV1PT0/UVSqVqAMAAACg95RKpao+njMhACiG9Hu5MWPGRN2HPvShqJs+fXrU3XPPPVF35513Rt3WrVujzl6Imhp/iQoAAAAAAAAAACg4Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACi0+t5+AgDsuerrs4+ZUaNGRd2pp54adRdddFHUTZ48OerS32PVqlVRd/vtt0fdf/3Xf0XdsmXLoq69vT3qKpVK1AEAAACwa2prd/5/25OmpqamprGxMep6enqirru7O+rK5XLUOWOC/7dSqRR1DQ0NUdfS0hJ1++yzT9Sl13l6Nr1t27aq/lzgL0vXlmHDhkXdF77whag777zzom716tVRd88990SdvQZvBn+JCgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLT63n4CAOx+amuzGdzGxsaoGzJkSNQNHTo06np6eqKuoaEh6gYNGlTV7uKLL466kSNHRt2VV14Zda+88krUdXR0RF2lUok6oG+pq6uLunQN79evX9SVSqWoa29vj7rOzs6o6+7ujjrgrZOuB/Yau5/0PiHdrwNAX5DuXerrs69bWlpadtqkZ0wDBw6MuvT+adu2bVG3devWqEvPmNL7NvtDdgfpuUt61n3UUUdF3cc//vGomzx5ctQ9//zzUXfFFVdE3WOPPRZ1ra2tUeeeAv6y/v37R93HPvaxqDvvvPOirlwuR931118fdY8++mjUpWfJsCv8JSoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQ6nv7CQBUU6lUirpKpfImPxNqampqenp6om7Lli1R98ILL0RdXV1dVX/ugQceGHWjRo2qavf+978/6kaMGBF13/zmN6PulVdeibpyuRx1wBvT2NgYdWPHjo26973vfVF3zjnnRN24ceOibtu2bVH3+9//Pup+9atfRV362dHe3h519hDw/1Zbm/0/rbRL9xquy7+svj478unfv3/UJXv79N8sXXPZs6X37+n9XXr/mXZ9Xfr6VZs1lyJqaGiIuvTeaMaMGTttJkyYED1Wek12dnZG3caNG6Nu3bp1UbdixYqoW7NmTdS1trZG3Z6y1tO3pJ+9zc3NUXfcccdF3Ze+9KWo23vvvaMuXQ+GDBkSdf369Yu6dE9nrwF/WXqPP3v27Kj727/92zfydP4vV155ZdRdf/31UZfuSbq7u6PO2sKu8JeoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqvv7SdA31AqlaKutjabu6t2V6lUoi5VLpejrqenJ+qq/fz46/m3eGukr3N3d3fUbd68OeqeeeaZqFu2bFnUPfTQQ1F30EEHRd0pp5wSdccee2zUDR06NOpOPfXUqFu4cGHU/eQnP4m6rVu3Rh0UTbqvam5ujrpjjjkm6r74xS9G3cEHHxx1jY2NUVft3zddI9M1/JVXXom69vb2qIMiSteDpqamqOvq6oq69L6taNJ/j2nTpkXd0UcfHXX333//TptVq1ZFj2XN3bOlZz3p3mDixIlR19HREXXLly+Pura2tqir9jlEQ0ND1KX3iy0tLVG3ZcuWqNu4cWPUpecBznHoTXV1dVE3efLkqHv3u98ddccdd1zUJdIztfQaT/cZabd69eqoe/zxx6Nu7ty5UZeuVfab7Ir6+uwr1XQf/tnPfjbq9tprr6h77bXXom7t2rVRl+6FBgwYEHXpfaC9AUWTnq2OHj066v7xH/8x6gYPHhx1t956a9Rdc801Ubd+/fqo6+zsjDprBm8Gf4kKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAotPrefgK8uerq6qKuubk56kaPHh11kyZNirrDDjss6qZNmxZ1w4cPj7qnnnoq6u69996oW7hwYdRt2bIl6iqVStRBb0nfo+VyOera29ujrqOjI+o2btwYdY2NjVG3dOnSqHv44Yej7h3veEfUfeYzn4m6dO37m7/5m6i74447ou7ZZ5+NOmsae4pSqRR1w4YNi7r0mvy7v/u7qBsxYkTUtba2Rt2iRYuiLn1d9tlnn6jr169f1KW6u7ur+niwO6itzf6/1JAhQ6LugAMOqOrPTfcQ6d6vr0vXyXT9S++jP//5z0ddV1dX1N133307bTo7O6PHYs+WvpePPfbYqHvf+94Xdc8880zUJe/lmpqamiVLlkRdulal95/pGdiFF14YdQ0NDVF38803R90TTzwRdel5gPtF3gzpZ+/IkSOjLr13O/vss6Ouvn7nX8usWrUqeqz0vLmlpSXqBg8eHHXpWdQhhxwSdSeffHLUTZ8+Pep++tOfRt3q1aujjj1beh+TnvdceumlUTd16tSoW7NmTdTNmzcv6tK92n777Rd16feG6doMRZPsC2pqampOOeWUqEs/ezdv3hx1V155ZdStXbs26tKzWvcJ9CZ/iQoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACi0+t5+Avx1amuz+bdBgwZF3eGHHx51H/nIR6Ju9uzZUTds2LCoq6uri7r0dZk1a1bUnXTSSVH3xS9+MermzZsXdd3d3VEHfV2lUom6crn8Jj+Tv6yrqyvq2traom779u1Rd8stt0TdEUccEXXvete7om7s2LFR9+53vzvqnnvuuaizprGnaG5ujrr0mvxf/+t/RV1LS0vUvfbaa1F39dVXR93ixYuj7r3vfW/U7bvvvlHX2toadenv29nZGXXpZxb0plKpFHV777131F100UVRN3ny5KibM2dO1M2fPz/q+rr0/nPAgAFRl95Hf+ELX4i6vfbaK+p+97vfRd3KlSt32qT7a3ZP9fXZMWK6Zlx66aVRd+CBB0bd4MGDo+7VV1+Nuq1bt0ZduneZOHFi1H3sYx+LuvTMasGCBVHX3t4eden9u70VvSm9dzvttNOi7v3vf3/UpevQqlWrdtq8/PLL0WOtW7cu6tI1fO3atVG3Y8eOqDvggAOibsKECVF34YUXRt0TTzwRdffcc0/U9dbZJW+NhoaGqDv++OOj7sQTT4y69Mx57ty5UZe+70844YSoGzduXNTNnDkz6tK1Od1b2Wuwp0jPfj/1qU9FXbqm/eY3v4m6Z599NurS74Fcu+wO/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0Op7+wnw35VKpahrbGyMuqlTp0bd5z73uaibPXt21FUqlahbs2ZN1G3atCnq0tdl3LhxUTd58uSomzVrVtQ99dRTUdfd3R11wBuTrlXlcjnq2tvbo2758uVRd+2110bdaaedFnUDBw6MurPOOivqfvCDH0Td9u3bow56U7IHS/cPH//4x6OupaUl6hYvXhx13/rWt6Ju/vz5UXfAAQdE3RFHHBF19fXZrce8efOibtmyZVGXruHQm2prs//fNHbs2Kj73ve+F3WHHHJI1D366KNRt2DBgqhra2uLunSvlkrvt5uamqJu+PDhUXfRRRdF3Uc+8pGoS5/fgw8+GHW//e1vo66jo2OnTU9PT/RY9C3pGjRy5Mio+4d/+IeoO+6446IuPSPp7OyMuvT3HTp0aNTtvffeUXfuuedG3Tvf+c6oS/dW6d4v3Vulr3O113Coqck/A4899tio+9KXvhR1I0aMiLr0DHvu3Lk7bdL914YNG6IuvSZ37NgRdek5/Mknnxx1H/zgB6Nu1KhRUZe+B+bMmRN17it3T+n+f/To0VF36aWXRl3//v2j7ne/+13UpWfE27Zti7rm5uaoS7/3OuaYY6Ju+vTpUZeua65L+rq6urqoS89m0u+s161bF3XXXHNN1LW2tkad/T97En+JCgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLT63n4C/HX69esXdaecckrUzZw5M+o6Ojqibs6cOVH3s5/9LOrWrVsXdQMHDoy6f/iHf4i6t7/97VF3+umnR90vf/nLqGtra4s6oG+pVCpR193dHXULFy6MulWrVkXdfvvtF3Xjxo2LuvHjx0fdCy+8EHXQm0ql0k6b9NrYZ599oq69vT3qrr322qh7+OGHo66pqSnqPvCBD0TdhAkToi5dq377299G3ZYtW6IuXZvhzVBXVxd1e+21V9R9+9vfjrqTTz456hYtWhR1P//5z6Nu8eLFUVcul6MuWZtrampq6uuzo430PnratGlR94//+I9RN2vWrKjr6uqKunvvvTfqrr766qhbsmRJ1CX/btbc3VN6lnLRRRdF3Zlnnhl16bX7xBNPRN11110Xdel9VkNDQ9TNnj076s4555yoGzZsWNQ9++yzUZfurTZu3Bh1PT09UQe7orGxMeqOPvroqPvBD34QdZMmTYq69Ez8wQcfjLrbb799p83y5cujx9q0aVPUpfuvdD9SW5v9//x0zUj3rxMnToy69D41Xes7Ozujjr4lvR9LvwdK14ylS5dG3VVXXRV1L7/8ctSl1/mOHTui7rjjjou60047Leo+97nPRd38+fOjbuvWrVEHvSXd33zwgx+s6uM999xzUZeuVfb/FJG/RAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRafW8/Af67UqkUdQMHDoy6GTNmRF1DQ0PUPfnkk1H3L//yL1G3ZMmSqEsNGzYs6l5++eWoO+GEE6Ju3333jbohQ4ZE3aZNm6KuUqlEHfDGpGtzKr12t27dGnUrVqyIusmTJ0ddY2Nj1I0fPz7qXnrppajr6emJOngzJNd5fX22da6rq4u6jo6OqHvssceirrOzM+qOPfbYqDv99NOr+nN//etfR93ChQujrru7O+rgzZDeP+23335R981vfjPqTj755Khbu3Zt1P3v//2/o+6JJ56Iuvb29qhL1dZm/+9r8ODBUXfeeedF3aWXXhp16V4ovb+78cYbo+6GG26IuqVLl0Zd+u/m/nP3k65VRxxxRNR9+tOfjrr+/ftH3SOPPBJ1X//616NuwYIFUVcul6NuzJgxUTd79uyoGzlyZNTt2LEj6n76059GXboW2FvxZkjvjQ4++OCo+9d//deomzJlStSl7/t58+ZF3fXXXx91yXq1ffv26LHSz/F07UvPwNLPmFRzc3PUpc9v/fr1Uecsas+W7klOPPHEqv7cdL++ePHiqKv2fj29X7zsssuibtq0aVF30EEHRd2pp54adTfffHPUuc7pLQMGDIi69Lv89Bp/9NFHoy4904Ui8peoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqvv7SfAX6dUKkVdW1tb1G3dujXq1qxZE3Xd3d1RV1+fvQWbmpqibuLEiVE3bty4qEtf59rabB6xX79+UQe9JX3Pp11v/dy6urqqdpVKpapd+nsMGTIk6lLVfp0HDhwYdela39XVFXWp9N8Damqy98umTZuix+rs7Iy6/v37R90+++wTdem+7xvf+EbUNTc3R92cOXOi7rrrrou6zZs3R51rnDdDujeYPHly1P3whz+MuiOPPDLq1q1bF3Xf+ta3ou7hhx+Ouvb29qhLr8v0dR4xYkTUXXLJJVH3kY98JOrS9W/x4sVRd+ONN0bdHXfcEXWvv/561HV0dESd9XT3k+7Xx4wZE3Vf+tKXom7o0KFR99prr0Xd1772tahbsGBB1KV7sPSM6fDDD4+6k046KerSs6OHHnoo6u69996oq/YaDjU1+ft55syZUXfFFVdU9fF6enqi7umnn466f/7nf466dL3atm3bTptyuRw9Vvq7ptd4+m/b2NgYdbNnz466UaNGRV26v3n00UejLv0eg74l3QsNGzYs6qZOnRp1K1asiLrbbrst6nbs2BF16XWeSt/3zz33XNRdfvnlUff1r3896j73uc9F3YMPPhh1a9eujTqotvS+I/0eKN0bpNduqre+v0v3JOkep7f2Vuye/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0Op7+wnw31UqlajbsmVL1D311FNRN3PmzKibMmVK1J1//vlRt3jx4qgbMGBA1I0fPz7qRo4cGXXpv0d9fXYpNTQ0RF2pVIq69PlB+p5K38sDBw6MuqFDh0Zdek3uv//+UbfPPvtE3aBBg6IuXXO3b98edStWrIi6yZMnR136uqRrRvp7tLe3R11TU1PUpdLfo1wuR11PT88beTrsIZL31erVq6PHWrlyZdQdcMABUfexj30s6tra2qJu3333jbpVq1ZF3eWXXx51y5YtizrXJG+GdC80evToqPvmN78ZdbNmzYq6tWvXRt3Xvva1qLvzzjujbseOHVGXqquri7oxY8ZE3Wc+85moS+8/073B/Pnzo+7GG2+Muoceeijq0j1iZ2dn1Llf3HP169cv6o466qioS8+Euru7o+6uu+6KunTPlN5PNDc3R126B/vCF74QdcOGDYu69L7yF7/4RdStX78+6uyt2BXpnmnixIlR993vfjfq0nUo9dJLL0Xd17/+9ah79NFHoy5dJ5PrMv0cT6/x9N82XUsPP/zwqPvwhz8cdem5+RNPPBF1Dz/8cNSl/2b0Len7ecKECVE3fPjwqLv99tujrq9/RqfrS3rOdM8990Rdujc9/fTTo+68886LuiuvvDLq0vtFSKVnJKn02k0/29K1NP2MTs/Upk+fHnXpfjM921q+fHnULVy4MOo2bdoUddaW3ZO/RAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRafW8/Af67SqUSdTt27Ii6OXPmRN2UKVOi7ogjjoi6U089NepOPPHEqNuyZUvUvfLKK1G3evXqqOvu7o66+vrqXkrp+wBSDQ0NUTd16tSoe+973xt1b3/726Nu8uTJUTdkyJCoS3/fVLoWtLe3R93mzZujbuDAgVE3atSoqCuVSlHX09MTdePGjYu6CRMmRF1nZ2fUpf8eGzZsiLrt27dHXblcjjp2T8lnb3rt3nvvvVG33377Rd1hhx0WdXV1dVGXvuf/6Z/+KeoefvjhqHMN0ZvSvcFpp50Wdccff3zUdXR0RN0///M/R93dd98ddemeJN0bNDY2Rt3EiROj7tvf/nbUHXfccVHX1dUVdQsWLIi6W265Jermzp0bdevWrYu6dC/kfnHPlV6T/fv3j7qjjjoq6tIzjfQ+YebMmVF3ySWXRF1qr732irr9998/6tLfI70m//jHP0bdk08+GXXpZ4w1g5qafH0ZOXJk1H3pS1+KunTPlD6/JUuWRN23vvWtqHvssceirtrXW23tzv9ve/pY1d7Ppef/3/nOd6IuXZvT/dIPf/jDqFuxYkXUWSN3T+n7ftKkSVX9udX+jO4t6fs+PcdJz2BvuummqDvhhBOi7uyzz466X/3qV1G3devWqINUuhZUe5/R0tISdQMGDIi68ePHR93HP/7xqDv99NOjbtiwYVGXvi7pNX7bbbdFXbonWblyZdSl99u8NfwlKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNDqe/sJ8Ncpl8tR9+qrr0bdVVddFXWPP/541E2aNCnqBg4cGHXp7zF//vyomzlzZtSdcsopUVdXVxd13d3dUQepUqkUdWPHjo26z3/+81H3rne9K+qam5ujrrY2m+mtVCq90qXXeFNTU9QNHTo06tLXJe16enqiLn1+n/vc56LuYx/7WNQtX7486p5++umou++++6Luueeei7qtW7dGXfq+YvfT2dkZdYsWLarqzx08eHDUpfvDu+66K+rSa6i1tTXqoDeNGDEi6s4+++yoa2hoiLqFCxdG3SuvvBJ16XowaNCgqEs/82fPnh11n/jEJ6Jun332ibrt27dH3dy5c6MuXf+eeuqpqFuzZk3UpZ8f9hBU27p166Ju8+bNUZeuLemZy2GHHRZ16VlKV1dX1A0YMCDq6uuzY9OlS5dG3ZVXXhl1a9eujbr0/g5qavLzmUsuuSTqLrjggqhLz1PSz9Qf/OAHUZfuDdra2qKu2p/RyeOlZz3pmnbIIYdE3b/9279F3eTJk6Mu3c/98Ic/jLoHHngg6pzD79nSz+gZM2ZEXXqekp5dpo/X16VrX3q/8+yzz0bd888/H3X7779/1KX3n+kZsfs2Uu3t7VGX7oMmTJgQdSeccELUrVy5Muo++tGPRt2pp54adekanp45p3umYcOGRd2FF14Yden99o9//OOoS/elvDX8JSoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQ6nv7CfDm6uzsjLqlS5dG3erVq9/I0/mrdXR0RF25XI66+vrsrV9bm80ZViqVqEv/PSCVvkff9ra3Rd0pp5wSdYMGDYq61NatW6Pu5Zdfjrpt27ZFXV1dXdSNHz8+6vbaa6+o69+/f9SVSqWoS6VrVVNTU9Slr0vaTZkyJepmzJhR1Z/705/+NOqefvrpqEs/i9J/D94ayfU2YMCA6LEmT54cdY2NjVGXSt976WdH+njQm9LPyiFDhkTd8OHDo667uzvqWlpaou6cc86Juq6urqibMGFC1E2fPj3qxo4dG3XpurZly5aoe/TRR6Putttui7pFixZF3YYNG6Iu/ffwmU8qfa+0tbVF3X333Rd1PT09UXf44YdH3bhx46IuvR/bvHlz1KX7/6FDh0Zd+jpfccUVUffEE09EnbMjdkW6F5o1a1bUffzjH4+69Fwj/cz/0Y9+FHV33XVX1G3fvj3q0vUvfZ3TLtkzDRs2LHqs973vfVF38cUXR126j0zXqhtvvDHqfvnLX0ZdujazZ0vXoP322y/q0j3Ypk2boq5o0tcv/Q7gxRdfjLpDDjkk6gYPHhx1UG3pZ9b9998fdYcddljUzZ49O+qam5ujLr3W0mv8T3/6U9SlZz3pmf1FF10Uden3qaeffnrUXXPNNVFnj9O3+EtUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodX39hPgzVWpVKKuo6Ojql0qfX6pUqkUddu3b4+6+vrsEunp6Ym6zs7OqINUbW02Czt9+vSoGzJkSNSl19qmTZui7tprr426hx56KOoGDBgQdUcffXTUjR8/PurSNSNd+9K1JV3T1qxZE3WpxsbGqOvXr1/U1dXVVfXnjhs3Lur23nvvqHvuueeirlwuR10qvd6q/ZlaNMn778ADD4we65xzzom6dA3fvHlz1KXvgcMOOyzqJk+eHHXr16+Puu7u7qiDXZGukenavGLFiqgbM2ZM1KWfgSeddFLUNTc3R92IESOiLv1MbW1tjbrFixdH3e9///uoe/rpp6Nu0aJFUZeuV21tbVGX7tWg2tKzmeeffz7qli1bFnXXX3991KV7nHRtTvf1V1xxRdSlz+/FF1+MujvvvDPq0rUUdkX6Wf6+970v6kaPHh116RnnLbfcEnXp+rJ27dqoS6XnEOl5z8CBA6PukEMO2WnzqU99Knqs2bNnR11TU1PUbdiwIeouu+yyqPvpT38addu2bYs69mzp/V16X9TS0hJ16ZrW1dUVdbwx6Wdb+n5J987OYKm29H7n5ptvjroPfOADUZeeWaV7g40bN0bd/fffH3VXXnll1KX7vvTsbeLEiVH3tre9LeoGDRoUden+0BrUt/hLVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHV9/YToG+oVCq9/RTeUgMGDIi6+vrsEmltbY269HUu2r8Hf730vdLY2FjVx+vp6Ym62tpsVvfII4+MuoMPPjjqRo0aFXVjx46NusGDB0ddXV1d1JXL5ahbsWJF1F1//fVR96c//Snq0uc3aNCgqJsyZUrU7bvvvlGXvq+WLl0adc8991zUdXV1RR27p+T9fPbZZ0ePtc8++0TdmjVrou7Xv/511J100klRN3369Kg788wzo+6pp56Kuu7u7qiDXZHuSdatWxd1t956a1Ufb/jw4VGXrhsDBw6MuvQzK72Puffee6Nuzpw5Ubdw4cKo27ZtW9Rt37496rZs2RJ1PvPp69K1L73Gq32mUSqVoq6hoSHqjj766KibPHly1HV0dETdf/zHf0Td66+/HnXpvxvsivSM85hjjom69H578eLFUXf11VdH3caNG6MufX7pnmnEiBFRd+CBB0bdGWecEXXvfOc7d9oMGTIkeqx0bVmwYEHUffvb3466hx56KOp27NgRdc7Dqamp/h4i/X4nPa9obm6OuvT3KJr+/ftH3YwZM6IuvW9L7wPt1ai29D21bNmyqEvPrC699NKoGzZsWNSl19BLL70UdZ2dnVGXrvXp94Hpfi7db6Z7nPTx6Fv8qwEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVW39tPAHpDc3Nz1NXWZnOGbW1tUdfe3h51kKpUKlH30EMPRd0FF1wQdRMmTIi6wYMHR92sWbOiLlUqlaIuvcZ7enqibtu2bVH37LPPRt0Pf/jDqPvzn/8cddu3b4+69H2Vvs5z586Nurq6uqgbNGhQ1KW/79atW6Ouu7s76uhb0ut88uTJO21OO+20qv7MX/3qV1H3i1/8IurSa+jAAw+MusMPPzzqWlpaoi7dB6VrEOyK9DP6vvvui7pXXnkl6t72trdF3SmnnBJ16Wfg888/H3X33HNP1N17771Rl77O6f1TuVyOunSvln6WW4fYU/TWezn9uQMHDoy6v//7v4+6pqamqEvvn+bMmRN1HR0dUQdvhgEDBkRdumdPP1PTz+hJkyZFXXoPNXz48KhL72VOOumkqJs+fXrUpWfOiTVr1kTdr3/966j75S9/GXWvvvpq1HV2dkYd7Ir0rDGVnkOMGDEi6oYMGRJ11T5z7uv3J+ke7IQTToi6gw46KOqefPLJqFu9enXUQW9J16qrr7466tLv29L90vjx46Pu3HPPjbrkHL6mJl9LDz300KhLf9/0zCo9U1u7dm3U0bf4S1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAECh1ff2E4BqKpVKUTd69Oioq63N5gy3bt0adZ2dnVEHqXK5HHXz5s2Luv/4j/+Iuk996lNRN27cuKirr6/ux1H6umzZsiXqFixYEHV//OMfo+62226LukWLFkVde3t71FUqlairtvT5pTZt2hR1vfX70rfU1dVF3aRJk3bapPuHdevWRV26FmzcuDHqli1bFnU9PT1RN3bs2Kjr169f1EFvSvcG27dvj7rVq1dH3eLFi6Nu4sSJUbdy5cqomzNnTtQtXLgw6tJ1Lb3fSdehVPqZX+0O+MvSs5Tjjjsu6qZPnx51O3bsiLrLLrss6tavXx91sDtIP8uHDRsWdcn9U01NTc2//uu/Rl16ptvY2Bh16T1K+njp3iA9I7777rt32lx11VXRY6VnVulzq/Y+DXZFeq2lZ7rp/c4BBxwQdeecc07UvfTSS1GXnnGm97Pp9Zuuuelaevjhh0fd1772tahL3wc//elPo661tTXqoLek1+7rr78edem19p3vfCfq0mv8+OOPr2qXrgXp65euBbfffnvU3XTTTVGXnjU6i+pb/CUqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0Op7+wlANdXV1UXd+PHjo662NpszXLt2bdR1dXVFHVTb1q1bo+6Xv/xl1D3++ONRd+aZZ0bd/vvvH3WlUinqFi5cGHUPP/xw1L344otRt379+qjr7OyMup6enqgrmkql0ttP4S1VtN+32tLP8iFDhuy0aWhoiB6rra0t6tJ9y+jRo6PupJNOirrGxsaoS9cg71F2B+n7Od2vb968OeoWL14cddu3b4+6dA+xYsWKqEt/j/R1SdeDdE/XW+uLdQ3emObm5qi76KKLoq6pqSnq5s6dG3UPPvhg1HV3d0cd9Kb0vOf++++Pur322ivqBg0aFHUjR46MuvSzN+3a29ujbvny5VGXnh9dd911Uff000/vtEn/bcvlctTZ37A7SN+nra2tUXfTTTdF3cknnxx15557btSNGTMm6v7zP/8z6hYtWhR16f1iuja/5z3vibqzzjor6tI94mWXXRZ16WebM3b2FOnZzBNPPBF1l156adR94hOfiLp0LUjO4Wtq8v3ca6+9FnXpZ8Ktt94adStXrow695W7J3+JCgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLT63n4CUE11dXVRt++++1b157766qtR19XVVdWfC6lKpRJ127Zti7rHHnss6ubPnx919fXZx1FPT0/Updda+njp6wf0PaVSKepaW1ur0tTU1NQMHz486r785S9HXbpGzp49O+rSNe3xxx+Puh07dlT150JvKpfLUdfW1hZ1K1eujLqNGzdGXbqmpddlb92fWA9g95SuQVOmTIm6WbNmRV26Vl1//fVRt2nTpqiD3UH6mX/ZZZdF3bJly6LuxBNPjLqWlpaoS3+P9Az2oYceirpnn3026lasWBF16e+R7Dntlyii9H2f7g2efvrpqPvKV74Sdd/4xjei7uSTT466448/Puqqfe4ycODAqKutzf4Ox2uvvRZ13//+96Pu1ltvjbr0dYGiSdfIJUuWRN1Xv/rVqPs//+f/RF161p3+Ht3d3VHX3t5e1cdLv19k9+QvUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVW39tPAKqpf//+UTdhwoSoK5fLUbdy5cqogz1FpVKJus7Ozqp2ALuqq6sr6h566KGdNvfff3/0WCeddFJVu7q6uqhL1+YXX3wx6q699tqo27p1a9TBnqSnpyfq0j1Oulal0ucHsCv69esXdaeffnrUtfx/7dy/SmN5HMZhjsYUahjQwsvxBqwsxDvxKqwEm1yAdyCks9JCracQtIhiEKxE4p/Es91Wu8zLTjTufJ+nfsnJDJxM8uMz58ePaHd7exvtzs/Po1161gP/B+m/+dfX19Hu8PAw2vX7/Wi3tLQU7dI/R/qdaTKZzPS66W8t4Guk9+54PI52g8Eg2l1cXES7nZ2daLe1tRXtNjY2ol36WfXz589ol/69HB8fR7vhcBjt0s9w4Pekv4vS3cvLy++8HfhWPIkKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABKE1EBAAAAAAAAAACliagAAAAAAAAAAIDSRFQAAAAAAAAAAEBpIioAAAAAAAAAAKA0ERUAAAAAAAAAAFCaiAoAAAAAAAAAACitM+83AImmaaLd6upqtOv1etHu/f092j0+PkY7AOBrTafTaDccDn+52dvbi15rd3c32m1vb0e7tm2j3dnZWbTr9/vR7ubmJtql35egovT+TXcAnyE9c1lfX492m5ub0S797Ds9PY12zmbg36X322QymeluPB5HO4DPkH72pecao9Eo2h0cHMx0l35XS3epj4+PaOf3LAB/Gk+iAgAAAAAAAAAAShNRAQAAAAAAAAAApYmoAAAAAAAAAACA0kRUAAAAAAAAAABAaSIqAAAAAAAAAACgNBEVAAAAAAAAAABQmogKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABK68z7DUBiYSHr/Xq9XrTrdrvR7uHhIdrd399Hu6Zpoh0A8LWm0+kvN3d3d9Fr7e/vz3QHAPCZ0rOKtbW1aLe8vBzt0rOUk5OTaPf8/Bzt2raNdgAA/8Wsv2v47gIAX8uTqAAAAAAAAAAAgNJEVAAAAAAAAAAAQGkiKgAAAAAAAAAAoDQRFQAAAAAAAAAAUJqICgAAAAAAAAAAKE1EBQAAAAAAAAAAlCaiAgAAAAAAAAAAShNRAQAAAAAAAAAApYmoAAAAAAAAAACA0jrzfgOQaNs22r2+vka7y8vLaNfpZLfI1dVVtJtMJtEOAAAA4DsZjUbR7ujoKNqlZySDwSDajcfjaJeeMQEAAAD1eBIVAAAAAAAAAABQmogKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABKE1EBAAAAAAAAAACliagAAAAAAAAAAIDSRFQAAAAAAAAAAEBpIioAAAAAAAAAAKA0ERUAAAAAAAAAAFBa07ZtO5cLN808LssfrtvtRruVlZVot7i4GO2enp6i3dvbW7Sb020JAAAA8I8WFrL/i5mepaRnH9PpdKavBwAAAHx/8/qd70lUAAAAAAAAAABAaSIqAAAAAAAAAACgNBEVAAAAAAAAAABQmogKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABKE1EBAAAAAAAAAACliagAAAAAAAAAAIDSRFQAAAAAAAAAAEBpTdu27Vwu3DTzuCwAAAAAAAAAAPBNzSll8iQqAAAAAAAAAACgNhEVAAAAAAAAAABQmogKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABKE1EBAAAAAAAAAACliagAAAAAAAAAAIDSRFQAAAAAAAAAAEBpIioAAAAAAAAAAKC0zrwu3LbtvC4NAAAAAAAAAADwN0+iAgAAAAAAAAAAShNRAQAAAAAAAAAApYmoAAAAAAAAAACA0kRUAAAAAAAAAABAaSIqAAAAAAAAAACgNBEVAAAAAAAAAABQmogKAAAAAAAAAAAoTUQFAAAAAAAAAACUJqICAAAAAAAAAABKE1EBAAAAAAAAAACliagAAAAAAAAAAIDSRFQAAAAAAAAAAEBpIioAAAAAAAAAAKA0ERUAAAAAAAAAAFCaiAoAAAAAAAAAAChNRAUAAAAAAAAAAJQmogIAAAAAAAAAAEoTUQEAAAAAAAAAAKWJqAAAAAAAAAAAgNJEVAAAAAAAAAAAQGkiKgAAAAAAAAAAoDQRFQAAAAAAAAAAUJqICgAAAAAAAAAAKE1EBQAAAAAAAAAAlCaiAgAAAAAAAAAAShNRAQAAAAAAAAAApYmoAAAAAAAAAACA0kRUAAAAAAAAAABAaSIqAAAAAAAAAACgtL8A/cAU9x3zYNgAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 3000x900 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(\"=\"*60)\n",
+    "print(\"Visualizing VAE Reconstruction\")\n",
+    "print(\"=\"*60)\n",
+    "\n",
+    "vae.eval()\n",
+    "with torch.no_grad():\n",
+    "    test_dataset = datasets.MNIST('./data', train=False, download=True, transform=transform)\n",
+    "    test_loader = DataLoader(test_dataset, batch_size=16, shuffle=True)\n",
+    "\n",
+    "    data, _ = next(iter(test_loader))\n",
+    "    data = data.to(device)\n",
+    "\n",
+    "    recon, mu, logvar = vae(data)\n",
+    "\n",
+    "    plot_results(data, nrow=8)\n",
+    "    plot_results(recon, nrow=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8--XrDgpM-gV"
+   },
+   "source": [
+    "## Visualize Generation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 320
+    },
+    "id": "yZDuAQMEKG56",
+    "outputId": "b74b06ed-59cd-4d36-c870-ffaf5d87a006"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "Visualizing Random Generation from Latent Space\n",
+      "============================================================\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAACVEAAAKICAYAAABzbCh9AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAuIwAALiMBeKU/dgAAaKJJREFUeJzs/HmYnXWd5//Xqb0qlVQq+x6SEJIQ1oQdlEUECZvgbkOP+zQ92ratjmNfM+20rd3a43hpO5ft6LSog0ujDLa2IoqIEhAIEgiQhIQQsu9JpSq1L+f372++TU+9bA6pJPfj8ffzuuuk6tyf+3Pf551TKpfL5SoAAAAAAAAAAICCqh7tFwAAAAAAAAAAADCaDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodWO1g8ulUqj9aMBAAAAAAAAAIBjULlcHpWf65uoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqsd7RcAUEmlUinqyuXyK/xKgKKyDgEA8EpK95tFc6zvr4v2dzvW/x4p93cAAADF4puoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQiuVy+XyqPzgUmk0fiwAAAAAMMqO9WeDlX591dXZ/2VNH9UODw+/nJfzb/65AAAAcDSM1n2qb6ICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKrXa0XwAUSalUirra2uzUrK+vH7Epl8vRsfr7+6NuaGgo6tKfCwAAAFRe+gyi0qqrs/+zmXbJs4+qqqqqhoaGqJs4cWLUzZ07N+qmT58edYcPH466TZs2Rd327dujrru7O+oq/bzHcyEAAACOR76JCgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKLTa0X4BcCwrlUpRV12dzSM2NTVF3dy5c6Nu6dKlIzYvvPBCdKznnnsu6rq6uqKuXC5HHXDsSde+5ubmqGtra4u63t7eqDt8+HDUDQwMRB0A8P+W7g1S7hXg6Kj0uZauBWlXV1cXdRMnToy6M844I+pe//rXR91ZZ50Vdelzkp/97GdRt3PnzqhLn0WNlvR94JoAwGir9OdA9fX1L+fl/AuDg4NRNzQ0FHXDw8Mv5+UAwAnv2L7bBgAAAAAAAAAAeIUZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHVjvYLgEoqlUoV7aqrsznDhoaGqJs/f37U3XTTTVE3d+7cEZsf/OAH0bE2bNgQdcDxq7Y2u+xPmzYt6lasWBF1F1xwQdStWrUq6n72s59F3c6dO6Ouv78/6srlctQBwCulpqYm6saNGxd1l1xySdRdeeWVUZe+vh/96EdRl+4NOjo6om5oaCjqgJcnXQtaWlqibs6cOVF34YUXRt0ZZ5wRden907Zt26JuzZo1FT1ed3d31A0PD0cdAIy29HOb9Bo9YcKEqEvvi974xjdG3bJly6Kurq4u6o4cORJ1P/7xj6Pu7/7u76Ju//79Uec+C45Plf6sPO3S+5NKfx6Tvr7095L+O6yRxyffRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRa7Wi/AEhUV2fzfqVSKerq6uqirqmpKepmzpwZdbfcckvUXXTRRVH33HPPjdjs2bMnOtbg4GDUAcee+vr6qJs9e3bUve9974u666+/PuoGBgaibuPGjVGXqvS1o1wuv5yXA68472U4ftXU1ERdW1tb1F1++eVR9/73vz/qFi9eHHUdHR1Rt2nTpqhL9wadnZ1RxyvPtYiqqnxNa2lpibqlS5dG3VlnnRV16XOS1atXR93KlSuj7umnn466Q4cORV16n+V843iQrhvps9oJEyZE3bx586Ju+vTpUZfu1caMGTNik+5vDhw4EHXPP/981O3evTvq0n1fX19f1A0PD0edNe34lD6jSz+3mTJlStS94Q1viLp3vOMdUTdx4sSo27lzZ9Rt27Yt6saPHx916Z5p2bJlUferX/0q6oaGhqIOODrS+/J033LFFVdE3YwZM6Iuvc/avn171I0bNy7qzj777KhL19xf//rXUbd27dqoS/dMHB2+iQoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACi02tF+ARRbqVSKuvr6+qhraWmJuhkzZkTd8uXLo+6iiy6KunPOOSfqOjo6om7VqlUjNtu3b4+O1d/fH3XlcjnqgJevtja7TC9YsCDqPvCBD0TdTTfdFHXp63v88cejbuXKlVHX3t4edcPDw1GXXotS6fGsp8eW6uqR/29Bc3NzdKxJkyZF3ZIlS6Ju6dKlUTdnzpyo6+vri7pHH3006h555JGo27dvX9QNDAxEXXqOw2hK1paqqqqqurq6qJs8eXLUnX/++VHX1tYWdel52dvbG3WNjY1Rl96jWA/g6EjXtPQZTroGnXzyyVGXrlU//elPoy7dC6XPXTo7O6Mu/Xe4n+B4kO5x5s6dG3U33nhj1L3xjW+MupkzZ0ZdQ0ND1KXPSZLnBun+Jr2/S9eqhx56KOoeeOCBqFu7dm3U7d69O+rSf+/Q0FDU2UceHekeIn3usnDhwqh71ateFXXptfdv/uZvou773/9+1KX3T9OnT4+6t73tbVGXPktO90LpvwM4OtJnLldeeWXUfeQjH4m6dA1P78fuvPPOqFu0aFHU/emf/mnUpZ/vpHuIzZs3R53P6Y8tvokKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAotNrRfgEUW11dXdTNmDEj6i666KKou/TSS6PurLPOirqWlpao27dvX9Tdf//9UffrX/96xObgwYPRsYaGhqKuXC5HHRRRqVSKusbGxqhbvHhx1P3FX/xF1F1yySVRV1ubbQ/Wr18fdd/4xjei7rnnnou6np6eqBseHo4669rxqaamJura2tqi7pxzzhmxufbaa6NjXX755VE3ceLEqEvXjHQNSq/5b33rW6Nu9erVUffnf/7nUbdp06aoS9cCeCWk51sqXdPGjx8fden6snfv3qjr6OiIuv7+/qjbvXt31PX19UWdazm8PJVe09K9S/oMJ30288wzz0TdAw88EHV79uyJuu7u7qgbHByMOmsax4N07zJnzpyoS+8VVqxYEXVNTU1Rl95TpOd5b29v1CXnebqvSjU0NETdFVdcEXVz586NupUrV0Zd+jx8+/btUdfZ2Rl1AwMDUWdtfmmV3kOkx5s+fXrUTZo0Kep+9rOfRd13vvOdqEvvn9L31ZYtW6IufbaaPivzvodjS7r/Wrp0adTddtttUbdo0aKoa29vj7oXX3wx6tLP3tPP/NN9abo/TP8e1tLjk2+iAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACq12tF8AJ6aampqomzBhQtRdeumlUXfDDTdU9OcePnw46p566qmoe+SRR6LugQceiLqtW7eO2AwMDETHAv51pVIp6lpaWqLuyiuvjLo/+qM/irply5ZFXXV1Njv97LPPRt3tt98edQ8++GDUpWvu8PBwRbtKK5fLo/JzTxS1tdn2dPbs2VH3vve9L+puuummEZtJkyZFx0qvvdu2bYu6jRs3Rt2uXbuibsqUKVF3zjnnVLS79dZbo+5v//Zvo66vry/qRmstgN9HXV1d1KV7jVR3d3fUpa8vXf/S9erIkSNR59p77PC3OLGlz3oWLlwYdW95y1uiLr2W/9M//VPUpXswew2KKH3+0dzcHHXXX3991L3mNa+JuvR+MX1We+edd0Zdek+2f//+qEvWjXRf1draGnXp7/jaa6+NuhkzZlS0S/e56XsgfQaWvuftcV5a+nupdDd16tSoGzNmTNS9+OKLUdfb2xt1ld4bDA0NVfTn7tmzJ+p8tgTHlrFjx0Zd+gw2/VypoaEh6vbu3Rt1v/vd76Ju7ty5UXfZZZdFXVNTU9Sln1Nt3rw56np6eqLOXuPY4puoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqsd7RfA8aVUKkVdQ0ND1J1yyilR99rXvjbqZs+eHXUbNmyIupUrV0bdE088EXXbt2+Pur1790Zdf39/1AEvT2tra9S98Y1vjLqPf/zjFf25AwMDUff8889H3Q9+8IOoe/jhh6Ouvb096oaGhqJueHg46srlckU7Xp50DzFmzJiou+SSSyraHTlyZMRm1apV0bH+z//5P1H37LPPRl16DvX19UVdc3Nz1L3pTW+Kuo985CNRt2zZsqhra2uLusOHD0ddumbAKyFd+2prs1vz9PxNr20tLS1Rl56X27Zti7r0fmdwcDDqgKNj3LhxUXfjjTdG3dSpU6Puhz/8YdQ9/fTTUZc+S7GHoIjSvcuECROiLr0fa2xsjLqNGzdG3X/+z/856tasWRN1vb29UVfJdSPdH06aNCnq6urqoi69Jz906FDUHThwIOrS+7v0b5E+Y/JM6Oio9O853ZPU19dHXfo+rfT9Sbrm1tTURF16fozWv8P5Bi8tveafffbZUff6178+6tJnTOn904MPPhh1qbe+9a1RN3PmzIr+3BdeeCHq0s/b0j0JxxbfRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRa7Wi/AI4vpVIp6saNGxd15513XtTNmjUr6rZu3Rp1P/jBD6Ju1apVUdfR0RF1PT09UTcwMBB1wMuTrlXXX3991P31X/911LW0tETdvn37ou7ZZ5+NunRNS4+3f//+qBsaGoq64eHhqCuXyxXtOLak74MdO3ZE3V133RV169atG7FZs2ZNdKyDBw9GXaWv9+k+LT03+vv7o666Ovt/GenPrampiTo4kVT6PKqtzW71071Qa2tr1KV7l7q6uqhzLYejo76+PuouvPDCqLv66qsr+nPXr18fdYODg1GX7pmAf11TU1PUpc8/+vr6oq69vT3qGhoaoi59falKri9tbW1Rd9NNN0XdVVddFXXp3+LRRx+Nuvvvvz/qtm3bFnVdXV1Rlz6Lst88OtLfc3oOpfcn6ecx6X1MKv13pPdF48ePj7p0bT5y5EjU2TPB0TF9+vSou/XWW6Nu6tSpUZee4+nnQA8//HDULVq0KOouuOCCqEvvK7u7u6Pu17/+ddSln0+kn3dwbPFNVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHVjvYL4NhQKpWirr6+PuoWLlwYdeedd17U7d+/P+r+8R//MeoeeuihqOvq6oq64eHhqEt/z2lXLpejDoqmoaEh6s4666yo+8QnPhF148aNi7p9+/ZF3d133x11u3btirpt27ZF3YEDB6Kuv78/6oaGhqIuXdOsfcen9O/W09MTdWvWrIm6tWvXRl1nZ+eITfra0n1BpVVXZ/8/YurUqVH3pje9KeoaGxuj7tlnn4269vb2qEvZV/FKqPT7Jb1W9vb2Rl2610jXq6ampqibNWtW1M2ZMyfq0rU+XZ+haNJrYGtra9SdfvrpUVdbmz1uTM/dpUuXRt3WrVuj7vnnn4+6dC3t7u6OutHaI8IrIX1u8NRTT0Xd/Pnzo27JkiVR95d/+ZdRt27duqh78cUXo66vry/qampqRmzSte/MM8+MusHBwai75557ou7OO++Mug0bNkRdus/17OjEll4r0/dz+r5K73fSPVO6B1uwYEHUXXzxxVGXrhubN2+OuhdeeKGix0vXSOcvJ4q6urqou+yyy6LuNa95TdSl92MDAwNR9+CDD0bdnj17ou7d73531E2YMCHqUjt27Ii6+++/P+rSGQJr2vHJN1EBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFVjvaL4BjQ01NTdRNnTo16m688caoa2xsjLqf//znUffYY49FXX9/f9Q1NTVFXVtbW9QNDg5G3ZEjR6Lu8OHDIzYDAwPRscrlctSlKn08qKqqqqqtzS5bS5YsibrPf/7zUTdz5syoS8/dr3/961G3devWqKuvr4+6PXv2RF1nZ2fU9fX1Rd3w8HDUWTeoqqqqGhoairpDhw5V9Ocm79PReo+WSqWoGzNmTNRdddVVUXfqqadG3b59+6LugQceiLr095yufen+K33vWdN4JaTv0wMHDkTdpk2bom7BggVRN2fOnKibMmVK1N16661Rt2rVqqjbtm1b1KXnORRNes367W9/G3XpuZauGePHj4+6N73pTVG3efPmqHvuueeibs2aNVG3ffv2qEvvs+w1eCWke93kmWRVVVXV9773vagbO3Zs1L3mNa+JuoULF0bd4sWLoy6Vrn/J+Zs+0z148GDUffe734269G+2c+fOqKvk74QTX/rst6OjI+oaGhqi7uabb466c889N+rStWXZsmVRl+6Fqquz781Iz8trrrkm6n74wx9G3be//e2o27t3b9Sl99FQaemz2gkTJkTdFVdcEXXp/VNq//79UXfXXXdFXbpWXXbZZVGXXhPS+6f77rsv6p5//vmoS/fN6fvFXujY4puoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqsd7RfAK6tUKkVda2tr1L361a+Oujlz5kTd9u3bK9rNmjUr6pYsWRJ1p59+etTNnz8/6mprs1Nuy5YtUXfPPfeM2GzcuDE6Vnd3d9QNDg5GXblcjjqoqsrPjVNOOSXq/vqv/zrqli5dGnUDAwNR95Of/CTqNm3aFHXpWnXgwIGo6+3tjbrOzs6oGx4ejjrrAb+P9P0yNDT0Cr+SV166T2tsbIy6M888M+re9a53RV1NTU3UPfLII1F36NChqBszZkzUpdeOdA3v6Oio6PGsfVRV5dfK9Bqd3hcdOXIk6vr6+qJu2rRpUbdw4cKoO/fcc6PuzW9+c9R97Wtfi7r29vaoc/5SNF1dXVH39NNPR91zzz0XdeleY/LkyVE3c+bMqDv11FOjbvHixVGXPgN78skno+6FF16Iut27d0edvQuvhPR9tXbt2qj77Gc/G3UrV66Mute97nVRl64H06dPj7rm5uaoS+5l6uvro2Pt2rUr6p555pmo279/f9Sl9+TWFn4f6fslfXaZPjd47WtfG3Xp85l0j5Pej23dujXq0s+VJkyYEHVTpkyJuttuuy3qLr744qj75Cc/GXVr1qyJuvQzLUhVV2ffUZPuHxYtWhR16dqSXqPT+470HFqxYkXUTZ06NepS6X3Rr371q6jr6el5OS/nX0g/A7BnOrb4JioAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQakf7BfBvUyqVoq65uTnqLrnkkqi7+eabo278+PFRNzQ0VNGfO3369KibNGlS1LW2tkZddXU2j5h2PT09UTdu3LgRm3/4h3+IjrVly5aoGxwcjDqoqsrXqpkzZ0bdbbfdFnWvetWroq5cLkfdo48+GnVPPvlk1J133nlRN23atKhLf881NTVRl0p/btqlfw94JSTv0/S9XFubbbHHjBkTdeeee27UfexjH4u62bNnR92uXbuibtOmTRX9uen+de/evVG3Y8eOqBseHo46axW/j/T9MjAwEHUHDx6MusOHD0dde3t7RY/30Y9+NOrmzZsXdX/wB38QdU8//XTU3XfffVGX/j3gRNHf3x916bmRPutJ18jt27dH3TPPPBN1a9asiboZM2ZE3Zlnnhl1V111VdSle87f/e53UffAAw9E3aFDh6Iu/ftyYkvP376+vqhL9+w//vGPo+7hhx+OuqlTp0bdKaecEnVnn3121C1cuHDEZvny5dGxZs2aFXXps6gHH3ww6uD3kV7b0s8e1q5dG3WPPfZY1C1ZsiTquru7oy7da/z0pz+Nuueffz7q0teXPrdKn+O8613virobb7wx6r7xjW9E3fvf//6oe+ihh6LOHodU+llvY2NjRbtKP7tsa2uLuvQz+quvvjrq6uvroy69Jqxfvz7qtm3bFnXp7zm9tnF88k1UAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodWO9gvg/1YqlaKuqakp6s4///yo++AHPxh1J510UtT19fVF3YQJE6KuoaEh6np7e6Nu3759UferX/0q6jo6OqIu/XssWbIk6qZMmTJiU1dXFx1raGgo6srlctRBVVVVVWNjY9Rdc801UfemN70p6mprs8vbCy+8EHXpWnD66adH3bnnnht16Vq6devWqBs7dmzUpb+/lHWD0ZTurZL3fbr/mjNnTtRddNFFUffOd74z6hYtWhR16dqybdu2qOvv74+6cePGRV17e3vU7d+/P+o6OzujbnBwMOqsabwShoeHK9ql7+eDBw9G3cqVK6NuxowZUfeBD3wg6qZPnx51b3jDG6Ju1apVUXfgwIGosx6QSvcj1dXZ/3VMu/TnVnptGa1zI92T7Ny5M+oOHToUdTU1NVGXrpEXXnhh1F177bVRlz6L+tznPhd16R4sfc4EVVX5+tLV1RV16Xpw+PDhqNuyZUvUpc+PWlpaRmw+/OEPR8dKn5XdcMMNUXfHHXdE3ZEjR6IOqqryvUFPT0/UPfXUU1GX3u9MmjQp6tJrYPqsNl2D0mtquqdLpZ97feITn4i69evXR91HP/rRqPtv/+2/Rd2b3/zmqEvXekjXtPTZwrp166Iufeacfi43c+bMqJs2bVrUjR8/PupS6Wf+u3btirrJkydH3d69e6Mu/fumz+IrvYbz8vgmKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNBqR/sFFEWpVIq6+vr6qFu8eHHUfeADH4i6U045Jeq6urqibtu2bVG3a9euqNu6dWvUPfjgg1H33HPPRV1PT0/UzZs3L+ouueSSqBscHIy6hx56aMQm/Vv09/dHXblcjjpObDU1NVG3YMGCqHvve98bda2trVHX3d0ddelasGjRoqi7/PLLoy79d+zbty/q0r9Huqb19vZGXbpWWTcYTen5MXny5BGb8847LzrW9ddfH3UXXnhh1E2aNCnq+vr6om7Dhg1R98QTT0Rdupbu3bs36vbs2VPRzh6HIkrfz+m1vKOjI+qS+5Oqqqqqa665JurSdTft5s+fH3Xt7e1Rl/7+OP6kz3Bqa7PHauPHj4+6GTNmVPTnHjhwIOrSa+rQ0FDUHeuqq7P/Uzpu3LioS++z7r333qhL16B3vvOdUXfZZZdFXfr6Vq5cGXUnyvuFY0u6x0nff+nzo/Rea3h4OOoOHTo0YvOd73wnOlZ6/zlr1qyoS+8/X3jhhahzn0VVVf4+GBgYiLp0j5NeU9NnR+k5nv470uON1nmUvr70fvHOO++MurPOOivqVqxYEXV/+Id/GHWf/exnoy59zsSJKz030vusu+++O+omTpwYdWeeeWbUNTc3R11LS0vUpWtpuqal+7S6urqoS/dC+/fvj7p0f5g+O0r3r/ZWR4dvogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAAqtdrRfQFFUV2fzalOmTIm6m2++OeoWLlwYdfv27Yu6++67L+p++9vfRt2mTZuibs+ePVHX2dkZdenf46STToq6P//zP4+6008/Pep+9rOfRd0Pf/jDEZvDhw9HxyqXy1HHia1UKkXduHHjou6mm26KutmzZ0ddanBwMOrSNXLy5MlRN378+KhLX9+hQ4eibsOGDVG3efPmqDty5EjUDQ8PRx28EtL1auzYsVF3+eWXj9i88Y1vjI61dOnSqGtsbIy6/fv3R116jqf7vvb29ooe78UXX4y6gwcPRl1/f3/U2ePAvy49P4aGhqIu3eOk60ZfX1/UpXu1BQsWRN3TTz8ddenvxTp0/EmfGaT3RWeeeWbUXXjhhVHX0NAQdatWrYq61atXR93evXujbrSu0enfrbW1NepmzJgRdelatWPHjqjbvXt31NXWZo91BwYGoq67uzvqrGm8EtL7u/Q8T9+n6d4lXddSNTU1IzZbt26NjtXV1RV1EydOjLqWlpaoS/9m8Puo9Lmb7te9n1+e9PecPuv+5je/GXWvec1rou7aa6+Nur//+7+PuvQ5HSeu9HORdH/9m9/8JurSfdC73vWuqFu+fHnUjRkzJurStTRdM9LP/NNrQvq5V3r/5NpxYvNNVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHVjvYLKIqampqomzp1atQtXbo06vr6+qLu/vvvj7rvf//7Ubd9+/ao6+7ujrr09zdlypSou+aaa6Lu3e9+d9TNnDkz6u65556o+/jHPx51+/btG7EZHh6OjgVVVVVVpVIp6tJzbfHixS/n5fwLg4ODUZeuGem529zcHHWpXbt2Rd13v/vdqEvXlm3btkXd0NBQ1JXL5aiDV0K6XtXV1UXdwMDAiM2BAweiY23atCnq0rVgz549UZf+ThYsWBB16dq3d+/eqDt48GDU9ff3R501CI496b1Huh6k94vjx4+PulNOOSXqamuzRyXWoRNX+rdN983Tp0+PurPOOivq0vuxzs7OqEv3JD09PVHX1dUVdenvOd3jjBkzJuqWLVsWdS0tLVHX0dERdSeddFLU/dEf/VHUNTU1Rd29994bdZs3b466ZN/M8Ss936qrs/+bnd6PpdfedK+R3lNU+vlH+vtLpPdjDQ0NUZf+zVL2QRwP0vdpen6ka1UqvaaeKOdbuoa/+OKLUbd79+6oS/fic+fOjbr9+/dHHaT7jPb29qh74oknou7MM8+MuvS+KN3fpGtVev/00EMPRd1PfvKTqHvyySejLr2PTu970881T5S1/kThm6gAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCqx3tF1AU5XI56oaGhqKupqYm6hobG6OupaUl6tra2qIu/XfMmjUr6i6++OKou+SSS6Ju3rx5Udfb2xt1/+N//I+o+7u/+7uo6+zsjLr0fQWp2trsstDU1BR1Bw4ciLrdu3dH3bhx46Kuvr4+6tK1b3h4OOra29uj7qtf/WrU3XXXXVG3Y8eOqBscHIw6OB6k18D0mvrUU0+N2AwMDETHSteqrq6uinbnnXde1E2dOjXqUunrS9cg+xs4eqqrs/9Xle79Ghoaoq67uzvqSqVS1KX3x2mX/l44caXXop6enqjbsGFD1O3cuTPqFi9eHHVvfvObo27GjBlRt2rVqqjbu3dv1KVrRmtra9SdccYZUZfuhdL748mTJ0fd3Llzo66uri7q7r333qj70pe+FHX79u2LuvT+mGNLek1Nr4Hjx4+PuvQZbPq+37NnT9Sl62n6DLvSkudW6f1d+rdI79t27doVde7bOJGka1+6J0n3OIcPH4669PxNr9Gjdf6mP/fIkSNRd+jQoahLP4dMPytIr6nWSdL3QPrMNH3OnX62ne6/Uum/49FHH426b3zjG1H35JNPRl26llb63HX/dHzyZBAAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACi02tF+AUUxNDQUdXv37o269evXR93SpUuj7nWve13UXXzxxVE3MDAQdVOnTo26pqamiv7chx56KOr+8i//Muo2bNgQdX19fVFXLpejDiqtujqbrT18+HDUPfDAA1HX1dUVdWeffXbUnXLKKVGXri3p67v77ruj7sc//nHU7dy5M+oGBwejDk4k6bWyt7c36rZs2TJik17HZ8yYEXW1tdlWPN1HDg8PR119fX3UlUqlqOvv74+69PUBL196/jY0NERdW1tb1M2aNSvqpk+fHnWtra1Rl66TR44ciTrrFek+I70Grl27NuruuOOOqBs3blzUXXDBBVH3hje8IepuvvnmqKv0OZTumdI1raamJurSZ0zpfnPbtm1R97/+1/+KuvS+8tChQ1GXrqWc2NJ7hZNPPjnqrrzyyqhL9y7pc6b9+/dHXXqeV/peK3m+9Sd/8ifRsdI18plnnom69FmU59ecSNK9Qfp51nnnnRd16TP21atXR92uXbuibrQ+p0p/z+lztQULFkRdT09P1HV0dEQdVFp6rqXd3Llzoy69f0qlz1x++ctfRt3TTz8ddZ2dnVHnWQ+/D99EBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFFrtaL+AohgeHo66vXv3Rt0//MM/vJyX8y+8+tWvjroZM2ZEXV9fX9Tt2LEj6p544omo+/a3vx11Tz31VNR1d3dH3dDQUNTBaCmVSlE3MDAQdbt27Yq6np6eqGtvb4+6dA065ZRToi59fb/4xS+i7vbbb4+6LVu2RF369wD+deVyOeqSvcuBAweiYzU3N0dda2tr1E2ePDnq5syZE3UNDQ1Rl/57+/v7ow44empqaqIuXa+WLVsWdVdffXXUpfefY8aMibr9+/dH3bZt26LO/R2pdJ9x5MiRqHvyySej7r/8l/8Sdeeff37UrVixIuqWLFkSdekep7Y2eyzZ1dVV0S5dM5599tmoe/zxx6PuwQcfjLp9+/ZFXXq/mL5Poaqqqqq6Ovs/1yeddFLUXXnllVGXXnvXrVsXdek9z+DgYNQ1NjZG3QUXXBB1n/rUp0ZsFixYEB3r8OHDUffFL34x6jo7O6MOTiTpNbW3tzfqZs+eHXXpfdE555wTdffff3/Ubd68OerS5z3pfeW8efOi7j3veU/UTZgwIerSZ/vp55UwWsaOHRt16RqU3o+l9xPpfUx635vuSdIZDI6O9PPoY/0+1TdRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhVY72i+A/9vAwEDUbdq0Keo+/elPR91Xv/rVqGtubo66jo6OqGtvb4+6vr6+qOvv74+64eHhqCuXy1EHx7r0vTw0NBR16Tl04MCBqNu6dWvU7dixI+r2798fdS+88ELU3XHHHVGXrs3pmgYcPck6ma6Rg4ODUdfS0hJ1J598ctQtXrw46tJ/x86dO6Mu/ffaV8Gxp76+PupmzJgRdcuWLYu6SZMmRV2653z22Wejbv369VGXrmuQSq+B6X3C9u3boy69lv/4xz+Ourq6uqirra3s48b095d26dqSPqNL14x0D2bPxCuh0s+F0vNj8uTJUdfW1hZ173jHOyp6vPRZ8hVXXBF1V155ZdQlry+9JnzlK1+Jut/85jdRZx9EEVX6Ocnjjz8edfPmzYu66667LupWrFgRdTU1NVHX29sbdel95dixY6Ouujr7/o81a9ZE3Ze//OWoSz+vtFej0kqlUtQ1NTVFXfrMJf256f3T7t27o+7gwYNRl67NHFtOlDXSN1EBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFVjvaL4B/m8HBwag7fPhw1HV0dERduVyOOuDElq4F6Vq1a9euqPvpT38adTt37oy6NWvWRN26deuiLl1Lh4eHow44ekql0ohNuval53hra2vUnXHGGVE3adKkqEvXtK1bt0bd0NBQ1AFHT7pedXd3R93atWujbvXq1VFXV1cXdS+++GLUffnLX466jRs3Rt3AwEDUwWhJ9xppl9639fb2Rh1w/EqvgU899VTUpc9drrzyyqi77LLLKtqlampqoi69N9q+ffuIzRe/+MXoWD/4wQ+iLv2cAPjXpfdPv/zlL6MufT5z3XXXRV26lp588slRN27cuKjr6+uLuvXr10fdypUro+6HP/xh1G3evDnq0j0xVFr6DCd5fl1VVVXV09MTdem+pb+/P+o2bNgQdQcOHIg6GE2+iQoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACi0UrlcLo/KDy6VRuPHAnAcq67OZn/r6uqibnBwMOqGhoaiDjh+JXvThoaG6FgzZsyIussvvzzqXv/610fdtGnTou573/te1H3nO9+Jun379kVduuYCx550D5Z2tbW1UTc8PBx16fqSHg8A+H+rr6+PulNPPTXqPvShD0Vdeg81bty4qEt1dHRE3X333Rd13/zmN0dsVq9eHR3ryJEjUWcfBMev9D4r/dw1XcNT6cfM6TP2dL1Kf671jxPFhAkTou6DH/xg1P3BH/xB1G3evDnq/v7v/z7q7r333qjr6uqKOk5sozTK5JuoAAAAAAAAAACAYjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQiuVy+XyqPzgUmk0fiwAAPyb1NbWRt2kSZOi7pJLLqlo19fXF3V33XVX1D377LNR19PTE3XDw8NRBwAAHNvSZ/vpPVRTU1NFj1dfXx91vb29UTcwMFDRbmhoqCINAMD/V2NjY9RNmzYt6tJnv+3t7VGXPsOGqqqqqlEaZfJNVAAAAAAAAAAAQLEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKGVyuVyeVR+cKk0Gj8WAABeUbW1tVHX0NBQ0W5gYCDqent7o25wcDDqRul2AgAAAAAAOEGN1mcPvokKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAotFK5XC6Pyg8ulUbjxwIAAAAAAAAA/w/p5/mjNG4AHGMqvWaM1trim6gAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBotaP9AgAAAAAAAACAY0e5XB7tlwAcR06UNcM3UQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVWO9ovAKCSSqVS1JXL5Vf4lQAAABRLpe/H3N8BAMeT6ursewuGh4ejzl4IGG2VXteAE9uJsnfxTVQAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChlcrlcnlUfnCpNBo/FgAAAAAAAAAAOEaN0iiTb6ICAAAAAAAAAACKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKrXa0XwAUSalUirrq6my+sVwuj9gMDw9HxwIAjq70el9TUxN1yb6gqirfG9hDAK+U9L6oqakp6hobG6Ouu7s76vr6+qIuXXcBAP7/Jfd4ra2t0bFaWlqibv/+/VHX09MTdfZBAACcqHwTFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGi1o/0C4EQwZsyYqFuwYEHUXXTRRVF35MiREZuVK1dGx9q+fXvUDQ4ORh0AnGhKpVLUNTU1Rd38+fOjbtGiRVGXXqPXrVsXdbt27Yq6np6eqBsaGoq6crkcdcCxp66uLuqWLl0adf/+3//7qEvXyfvvvz/q7rjjjqjbtm1b1KXrH/DSqquz/wOa7sHGjx8fde3t7VHX3d0ddfY4cPxK7wVramqibt68eSM2N998c3Ss9Dnyd77znaj753/+56jr6uqKOgCgMtL9SENDQ9RNnDgx6iZPnhx1zc3NUTc8PBx1Bw8ejLqdO3dGXaWfYXNi801UAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodWO9guA0VAqlaJuzJgxUXfjjTdG3S233BJ1p556atR1dHSM2MyYMSM61te+9rWoa29vj7pyuRx1APBKSq/51dUj/9+C1tbW6FiXX3551KX7gpNOOinq9u7dG3Xr1q2LuieffDLqVq9eHXVbt26Nuq6urqgbGBiIOnsS+Nela2RTU1PUnXHGGVH32c9+tqLHS9bwqqqqqkmTJkVdZ2dn1H3729+OukOHDkXd0NBQ1MGxLl1bGhsbo2758uVR95/+03+KurPOOivqnnrqqaj74Ac/GHWbNm2KOnsXOPbU1mYfo0ycODHqLrzwwhGbW2+9NTrWzJkzoy7dj6xcuTLqenp6om54eDjqeGnpNTW9dqTHGy2ugUARpWtzW1tb1K1YsSLq3vGOd0Rd+mymubk56tJ/b7rXWLt2bdR9/vOfj7oHHngg6g4fPhx1rm3HJ99EBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFFrtaL8AqKRSqRR1U6ZMibobb7wx6j7ykY9E3axZs6Iu/XdU8lh1dXUVPV65XI46ADgWNDU1jdicf/750bHe+973Rt2ZZ54ZdUNDQ1GXXqMbGxujbsGCBVF37rnnRt3KlSuj7ne/+13Ubd++Pep6e3ujbnh4OOrgeFBdnf1/qTFjxkTdihUrou7jH/941C1evDjqamuzRxaDg4NR19zcHHXTp0+PukmTJkVdV1dX1KXrlXstRku610i7hoaGqJs3b17ULVy4MOrSc/ess86Kuvnz50fdiy++GHXpmga8fOl6le6t0uerSdfW1hYdq76+PupS6f2n/QhVVd4HL1e6F2ptbY269H6iu7s76qwHcHTU1NRE3dy5c6PuhhtuiLrTTz896lpaWqIu3S+l0p+7fPnyqPvEJz4Rdf39/VH3q1/9Kup6enqijmOLb6ICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKrXa0XwAkqquzeb9JkyZF3W233RZ1f/zHfxx1bW1tUZfq6+uLuk2bNo3YrF69OjpWT09P1MHxIF0zRkupVBqVn1sulyvanSiK9u89UaTnUV1dXdTNnz9/xObf/bt/Fx1r2bJlUZfavHlz1G3cuDHqWlpaom7atGlRt2DBgqi7/PLLo+7JJ5+Mum9961tR98gjj0RdZ2dn1A0NDUUdvBLStS89z9/61rdG3X/8j/8x6ubMmRN1NTU1UTc8PBx16b3M3r17o66/vz/qJkyYEHW7du2KuoGBgagbHByMOqi0dN+crlVp19raGnVjx46NunQNqnQHHL/SPUlXV1fUNTQ0jNjU19dHx0rX5q1bt0Zdd3d3RX8uxxZ/t6MjPX/POOOMqHvzm98cdTt27Ii6+++/P+qSz5+qqvLPs1KNjY1Rl+7B0vvF9H7MecRoST/36u3tjbqdO3dGXfosNH320dHREXUzZ86MunQtTZ7/V1VVVb373e+OumeeeSbqtm/fHnXpfpOj49j+lBkAAAAAAAAAAOAVZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFVjvaL4BiK5VKUTdjxoyoe//73x91t912W9S1tLREXblcjrre3t6o27RpU9T90z/9U8WONTg4GHVQVVVVVVNTE3UNDQ1RV19fH3UTJ06MukmTJkVdU1NT1LW1tUVdbW12Wa2rq4u65ubmih6vp6cn6g4dOhR1HR0dUbdr166o6+7ujrr+/v6oS/+9XV1dUWedPLake4ixY8dG3c033zxi86pXvSo6VroWrF69Ouq+8Y1vRN2BAweibvr06VG3ZMmSqFu+fHnULViwIOquuuqqqFu0aFHUpb+/7373u1F38ODBqBseHo46+H2ke5d3v/vdUfehD30o6tL7sXRtTu+fjhw5EnXPPfdc1K1fvz7q0nV88eLFUdfe3h51W7dujbp0z2QdYrSk5/jQ0FDUTZ48OerGjRsXdelald5P7N69O+rSfy9w9FR6vUqPN3PmzBGbdN83MDAQdS+88ELUpc+vOTrS9xRHR7qHSPcub3/726PuyiuvjLqf/vSnUZc+K0ufTafv0/Hjx0fd2WefHXXpM/FVq1ZF3Z49e6LOM2IqLb13f/HFF6PuRz/6UdSl58a2bdui7tlnn4269POnqVOnRt2nP/3pqLv00kujLn3Wkz4r27FjR9RxbPFNVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHVjvYL4MRUKpWi7uSTT466P/3TP426t7/97VHX0tISdeVyOeq6urqibtWqVVF39913R93vfve7EZvOzs7oWOm/lWNLeq5VV2czs83NzVF32mmnRd2VV14ZdRdeeGHUzZ07N+pqamqibnh4OOrS33P6cwcHB6NuYGAg6hobG6Outja77Kf/jvb29qjbsmVL1G3evDnqVq9eHXUbNmyIunXr1kVd+u/l6Kirq4u65cuXR92tt946YjNu3LjoWFu3bo2673//+1G3fv36qGtoaIi6dC3o6OiIuvQcOumkk6Luuuuui7oZM2ZE3Qc/+MGoS9f6r3/961F35MiRqIOqqnwP9oEPfCDq/uzP/izqJk6cGHXpXjLdW+3duzfqfvazn0XdfffdF3XpHmfMmDEV7SZNmhR1hw4dirre3t6oS/8eMFrq6+ujbvHixRU9XuqFF16Iup07d0ad5y5w4kv3BpdccsmITbqmHThwIOrS+7ahoaGogyJKn6ekz86vueaaqEv3/w8//HDUPffcc1GXPtdIn9GlnwfedNNNUbd79+6oe/zxx6MORkt6n5Cek7/97W+jLn3WvW/fvqhLP49On1Wkn3v19PREXfrsN3196ed8HJ98ExUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBotaP9Aji+lEqlqJs1a1bU3XbbbVF3yy23RF1LS0vUpQ4fPhx1P/rRj6Lu7rvvjrrt27dHXVdX14hNuVyOjpVK3wNpV+nXd6xLfy+1tdny3NTUFHXTp0+PuhtvvDHqbrrppqgbM2ZM1O3fvz/qHn300ajbvHlz1G3cuDHqdu3aFXUDAwNR19HREXXp+yV9H0ydOjXqZsyYEXXjx4+PukmTJkVdf39/1KWSNbKqqqqqp6enoj+Xl6e6OpvxnzZtWtR96EMfqtjxjhw5Eh3rvvvui7r29vaoS8/JSq+56RrZ2dkZdUNDQ1F31113Rd0HPvCBqLvhhhui7s/+7M+ibsOGDVH3i1/8IurS3wvHp/r6+qh717veFXUf/ehHo66trS3q0r3G8PBw1KV7pi996UtR973vfS/quru7oy5dT08++eSoO+2006LuggsuiLre3t6oS68f6fpStHsyjh3p/cRJJ50Udek+Mj03Hn/88ahL7++AE9/s2bOjbs6cORX7mZs2bYq6nTt3Rl2674MiSp+7pJ9npfdt6edKld67pPcJY8eOjbqzzz476pYvXx51P/nJT6IufUZs/WO0pOda+vlTpZ8Z1NXVRV36DCz9POvcc8+NumXLlkVdauvWrVG3Z8+eqLO2HJ98ExUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBotaP9Ajg21NTURN38+fOj7mMf+1jUveUtb4m65ubmqEsdPnw46r7xjW9E3Z133hl1+/fvj7rh4eGoGxwcHLHp7++PjlUul6OOo6OxsTHqFi9eHHV//Md/HHVnnXVW1B06dCjqPvOZz0Tdb3/726jr6emJuoGBgagbGhqKuvScTLvRUl2dzU6nXV1dXdQ1NDREXX19fdSlf9+urq6oS9dJjo70ffC2t70t6i666KKoK5VKIzYbNmyIjrVp06aoa21tjbo5c+ZU9Odu27Yt6vbu3Rt16dqcrrnpNebzn/981M2bNy/qzjzzzKh7//vfH3WPPfZY1B08eDDqOLbU1ma30un9zic+8Ymoa2tri7pkTauqyvcuO3fujLr0vPzWt74Vdel9W/rvTe6fqqqqqqZMmRJ16d9jzJgxUZfuSbZs2RJ1fX19UedekNEyefLkqJs+fXrUpWtBundZtWpV1KX3J8DxK33+cfHFF0fdhAkTRmzS6/NDDz0UdelzafsCiij9fGzBggVRd+GFF0Zde3t71N19991Rlz5PSe8D099Luqe75pproi69z3rkkUeiLn1GfKw/24f0fid9vj5x4sSomz17dtTNnDkz6tK19LLLLou69BlOZ2dn1P3qV7+KunQNt7c6PvkmKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNBqR/sF8Mqqrs7m5JYsWRJ1H/vYx6LuxhtvjLrm5uaoSx06dCjq7rjjjqi76667oq69vT3qmpqaom5oaCjquru7R2xKpVJ0rPS9knblcrmiXdGk58aKFSui7tWvfnXUPffcc1H34Q9/OOqef/75qBsYGIi6lPfVS0vXlkp3fX19UVdpw8PDUef9cnSk16P58+dH3Tvf+c6oa2hoiLq9e/eO2DzwwAPRsdavXx916b5g48aNUbdly5ao6+joqGiXrgWVPtfSa8ynPvWpqPvKV74SdcuXL4+6Sy+9NOruvvvuqOPoSPe6F110UdR98pOfjLq2traoS9fS9Hw7cOBA1H3mM5+JuvQ+68iRI1GX/jvS30tNTU3UzZ49O+oWLVoUddOnT4+6uXPnRt0TTzwRden9cX9/f9RBKj3X5syZE3Wtra0v5+X8C+na9+yzz0ZduhcCjl8tLS1Rd/bZZ0ddcp+aPkt55plnom5wcDDqoIjS5zPXXHNN1I0dOzbqfvGLX0Td1q1bo67S90Xp2nf55ZdH3WmnnRZ16XO11atXR12lP3uASkvP3XStSp8tpJ8bvuY1r4m6U089NerGjx8fdY2NjVGX2rFjR9Sla5D7wBObb6ICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKrXa0XwD/NrW12Z/unHPOibq/+Iu/iLqLL7446pqbm6OuXC5H3ZEjR6Lu4Ycfjrr169dH3dSpU6Nuzpw5Udff3x91nZ2dUbd79+4Rm97e3uhYw8PDFe2GhoairmjS93ypVIq6mTNnRl1dXV3U/eY3v4m6nTt3Rp33wYktXQ/S93Olz4/0eBwd6d7l7W9/e9Sl6196Hfze9743YvPtb387OtaePXuirtLv+XSf0dfXF3WDg4NRN1rS1/fUU09F3apVq6Lummuuibobb7wx6n70ox9FnWvq0TFx4sSo++QnPxl16VpVXV3Z/9908ODBqPvKV74Sden6l963VXoPkf7+2traom7hwoVRN3/+/KibMmVK1E2aNCnqLr300qhL17+BgYGos7cile77li5dGnUNDQ1Rl75Ht23bFnUHDhyo6M8Fjj3pXiO9lp966qlRV1NTM2KT7quef/75qHM/QRGl9wljxoyJuiVLlkRder6l90XpGtTe3h516XOhk08+OepuvfXWqEs/o/jf//t/R93+/fujzl6NY116/zR58uSou+SSS6IufXZ59tlnR126lqb7r3SNTJ9pNDU1Rd348eOjLl3TfJ51fPJNVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKHVjvYL4P9WV1cXdcuXL4+6z3zmM1F37rnnRl1DQ0PUpfr7+6Out7c36hYvXhx18+fPj7qBgYGo6+joiLpt27ZF3TPPPBN1v/nNb0Zs9u7dGx1raGgo6srlctSVSqWo46Wl50ZXV1fU9fX1Rd3SpUuj7tRTT426rVu3Rt2RI0eiLv29pF2l3/e8tEr//vw9jk8tLS1Rd9VVV0VddXX2fwGeeuqpqPv6178+YrNp06boWJVeW9J/a3q84eHhqDvWpf+O9FqZ7r9WrFgRdWeccUbUpX/f9H3FS6uvr4+69773vVF3zjnnRF1tbWVvubu7u6Pue9/7XtR98YtfjLrOzs6oS8/L9F4hPT/Sa8zZZ58dda961auibubMmVGX3kenzwPS9WXSpElRl/597cFIpWtfev9ZU1MTdem18vHHH4+6np6eqOPEll6zrJHHp3SPmO79Zs2a9XJezv9ly5YtUbdr166o8x6liCp937F79+6oO3DgQNS1tbVFXfq5V/o5Wnrf9o53vCPqTjnllKh7/vnno+7++++PuvQzADjWNTY2Rt3FF18cdW984xuj7rTTTou69PWl92Pp55XpOd7c3Bx1s2fPjrpXv/rVUffAAw9EnWcuxyffRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABRa7Wi/gKKor6+PugsvvDDqPvWpT0XdsmXLoq6xsTHqUsPDw1FXU1MTdW1tbVE3YcKEqCuXyxXthoaGou6UU06JuokTJ0bdzp07R2z2798fHau7uzvqKv2746X19PRE3c9//vOomzlzZtSdfPLJUfeFL3wh6g4dOhR1Tz31VNQ98cQTUbd27dqoS86hqqqqqq6urqjr7++PulKpFHWVPo/StTnlPOf3sWDBgqhL16ve3t6ou+OOO6Juy5YtIzaDg4PRsSp9bqT7jKKp9O/58OHDFT1eQ0ND1NXV1UXdwMDAy3k5hTdv3ryoe8973hN1TU1NL+fl/Avp33fVqlVR99//+3+Puvb29qhL9xDV1dn/00rvjydNmhR1y5cvj7o3vOENUbdw4cKoS8/z9L43XQ9mz54ddenv78UXX4w6SLW0tERdujan90/pXm3Tpk1Rl96Xw+8jfT+n3Je/tPT33NraGnWvfvWro665uTnqknu83/72t9Gx0mdWUETpfUx6Ht17770VPV5tbfYRbXo/MXny5KhbsmRJ1N1www1Rl16L/vZv/zbq9u7dW9GfC6MlfUYybty4qDvttNOiLv2MOf08K/2cb926dVGXfh6Y7tPe8pa3RF36e04/x0ifbXF88k1UAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodWO9gs43tXU1ETdKaecEnUf//jHo27ZsmVR19jYGHWpcrlc0eOlv79KS/8dQ0NDUZf+O1pbW6PunHPOibqenp4Rm+3bt0fH2r9/f9T19vZGHS9PX19f1P3617+Ouh07dkTdJZdcEnXLly+PutNPPz3qrrrqqqhbsWJF1HV3d0fdiy++GHW/+MUvou6JJ56IugMHDkRd+j4YHByMuvT3kv7cdI2s9LWDY0upVIq6RYsWRV1DQ0PUHTp0KOqefPLJqOvv7x+x8V4+tqTvvfQ9NXfu3Ir+3M7Ozqjj5amtzW5p3/CGN0TdlClToi59H6TrxrZt26Lu05/+dNSl9wDDw8NRl/576+rqom7WrFlRd+WVV0bd1VdfHXVLly6Nuubm5qhLfy+Vlt6TpeuQ6xup9D0/e/bsqJsxY0ZFf256bqxevTrq0jUSXgnW5pcnfVY7c+bMqDvrrLOiLt2bJtfohx56KDrWwMBA1KUqvc+F0ZS+T48cORJ1jzzySNQ988wzUZfed6Sf86WfQ950001RN27cuKi75557ou6Xv/xl1CXP6GA0pdfKdF+Qfnacfm6zbt26qGtvb4+6Bx54IOrS5/Dpz02f4Vx//fVRN378+KhramqKuvTvy/HJN1EBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFVjvaL+B419DQEHVXXHFF1J155pkV/bmp4eHhinbV1dl83uDgYNT19vZGXWdnZ9S1t7dHXVdXV9RNnDgx6qZMmRJ1TU1NUXf66adXpKmqqqpau3Zt1JVKpagrl8tRx0tLz7X0PfrMM89E3fPPPx91d911V9RNmzYt6tJzKF0jzz///KibMWNG1L3vfe+LutTOnTuj7oUXXoi65557LurWrVsXdRs3boy6Q4cORV1/f3/Upe9768uxJb0uLFq0KOpqamqiLl3/uru7o45jR/qeqquri7qZM2dG3ete97qoS9+jGzZsiLqhoaGo46U1NjZG3Wtf+9qoq/R9Vnq/8/DDD0dd+r5Kz6Pa2uyRQPp7Ttf6FStWRF16Xs6ePTvqWltboy7996b3van0vjd9v+zatSvq7K2otPScbG5ujrr0Pbply5ao27FjR0V/Lie2Sj8H8756edK/x5gxY6LunHPOibpZs2ZFXSp57pI+O0ql+5b02QycSNL3ffr505EjR6Iufb6Q3sek91mnnXZa1O3fvz/q/uqv/irqDh8+HHWulYyWSj+TTD/3Su+f0s/v0s+B1qxZE3Xp/VNfX1/U1dfXR136+V1bW1vUpQ4ePBh16TMca9rxyTdRAQAAAAAAAAAAhWaICgAAAAAAAAAAKDRDVAAAAAAAAAAAQKEZogIAAAAAAAAAAArNEBUAAAAAAAAAAFBohqgAAAAAAAAAAIBCM0QFAAAAAAAAAAAUmiEqAAAAAAAAAACg0AxRAQAAAAAAAAAAhVY72i/gWFUqlaJu7NixUXfhhRdW9Hjp60uVy+WoGxoairru7u6o27x5c9Q9+OCDUff0009H3datW6NueHg46hYtWhR173nPe6JuwYIFUdfa2jpis3DhwuhY9fX1UZe+B9L3FEdH+nfr6uqKuvQc37dvX9RVV2czvQ8//HDUffvb3466adOmRd2ZZ54ZdaeffnrUzZkzJ+pOO+20qDvvvPOiLv27Pfvss1F3zz33RN3q1aujrrOzM+oGBgaiznp1dKTnb1tbW9TV1NREXboXGjNmTMV+brovKNp7qtL70vRvNn/+/Kj7r//1v0bdvHnzou7AgQNR981vfjPq0jWNl9bc3Bx16fuq0u/nwcHBqEv3YOn9YrpetbS0RF26F3rzm99c0eNNnDgx6tL3QaWvMam+vr6oW7lyZdR961vfirp0b1W06xb/do2NjVF39tlnR136HCJ9j6bPmHp6eqIOqqqskf+a9FpZ6a62Nvs446STToq6yy+/POrSPVh6zU+ebx08eDA6VqrSfwvnBkWUvu8rfX6ka9Af/uEfRl16X/TlL3856jZu3Bh16X0qjJZK7zMuvfTSqJsyZUrUrV27NurWrFkTdbt374669NlWuracccYZUfcnf/InUZc+E0r3aatWrYq6w4cPR5090/HJN1EBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFVjvaL+B4VyqVoq6uri7qhoeHK9ql0uMdOXIk6p555pmo+/73vx91K1eujLoDBw5E3cDAQNSNGTMm6lL79u2Luvnz50ddQ0PDiE1bW1t0rKGhoagrl8tRx4ktfR+k76u0S8/dvr6+qDt48GDUvfDCC1F37733Rl16Xs6dOzfqFi9eHHUXXHBB1M2bNy/qbrnllqibMmVK1D3yyCNRt2vXrqjr6emJuvT9x0tL14Pdu3dHXfr3mDBhQtQtWrQo6p5//vkRm66uruhYg4ODUVfp/Vz6t0j3rzU1NVHX1NQUdenf7LWvfW3U3XbbbVGXrpHp3+0HP/hB1D322GNRV+n3AS8t3RtUeq9bX18fddddd13UpWtaev85fvz4qGttbY26dI+T/l7Sdai6urL/Pyx9H3R3d0fdfffdF3Wf+tSnoi65ZlVV5esapJJnEFVVVVVLly6NuvQcT/eHmzdvjrr02pvumTwnObEV7e+bvu/Ta2+6J0l/7rhx46Lu/PPPr2iXrld79+6NujVr1ozY9Pb2Rseq9H6p0veVRTuH4PdRW5t9RPv6178+6ubMmRN1zz77bNR997vfjbr0fhtGS3oNTJ9dXn/99VF32WWXRd3hw4ejbt26dVGXnpPptTz9rPzSSy+Nuo997GNRt2TJkqhLrV+/PuruueeeqEs/K+D45JuoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQqsd7RdwvBsYGIi6zZs3R93hw4ejrlQqRV2qs7Mz6p577rmo+/nPfx51q1evjrp9+/ZFXXd3d9RVV2fzg8PDw1E3duzYqKupqYm6Sv59e3t7oy59L5fL5ZfzcuBlqfTal+rv74+6oaGhqEvXqr1790bd2rVro+7xxx+PumuvvTbqLrrooqi7+uqro66joyPq0mtWX19f1KV/N15ael1Ys2ZN1PX09ETd+PHjo+7DH/5w1NXV1Y3YpOfQoUOHoi79t6ZrX7q/SX93ixYtirrly5dH3eWXXx51p512WtQ1NTVFXboX+uEPfxh1n/vc56LuyJEjUcfL09XVFXUPPvhg1J1++ulRV+n9//Tp06Nu2rRpUZeuzem6kUrXq0rv6dJ/7+DgYNTt2rUr6r761a9G3e233x51e/bsibr0PhUqLd1DzJw5M+rStSB9XpGeu+nanOwPq6rytaXSz1PS43mOQ1VVfs2vrc0+LhgzZkzUTZgwIerSvVW6V3vnO98ZdVOnTo269J5i5cqVUZc8Y0/P3fr6+qhLn33YZ8DLl+5x5s6dG3X/4T/8h6hLz/NPf/rTUbd79+6os9fgWJfug2bPnh11V1xxRdSdeuqpUZfOEKT7qnR/k65B6b/3lltuqejPTf9uO3fujLovfOELUZd+3pbeB3J88k1UAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAodWO9gs4VpXL5ag7fPhw1N1+++0v5+X8C8uWLYu6+vr6qDt06FDUbdy4Meoef/zxqNu5c2fU9fb2Rl36d6upqYm6lpaWinY9PT0V7QYHB0dstm/fXrFjwWgbrXO3ujqbOW5qaqro8caMGRN13d3dUTc0NBR1W7dujbqTTjop6jo6OqKuoaEh6mprs+1Lek3g5Ul/z+ne4Je//GXU3XDDDVG3aNGiqPv85z8/YnPgwIHoWPv374+69HqfSs+hKVOmRF1ra2vUpWtfeu4ODw9H3b59+6LuK1/5StT9z//5P6Pu4MGDUWcNOjrS+4S77ror6s4+++yoe9WrXhV1jY2NUVcqlUalGy3p+ZGuB+le4xe/+EXUfeELX4i6J554Iur6+/ujDkZLen+S7iEmTZr0cl7Ov5CeQ9OnT4+6iRMnRl16/zQwMFDR46XPZ9LjpWtpujaP1jWm0q/vRNmrpf/e9HnKuHHjom7p0qVRd9lll0Xd4sWLo+6ss86KupkzZ0Zd6ne/+13U3X333VGXPK/t6+uLjpWe4+laf6zvI+F4kD6fee973xt1kydPjrr7778/6h544IGo85kRJ4p031dXVxd106ZNi7oJEyZEXXrtXbFiRdRdeumlUZc+A5szZ07Upc+IU3v37o26z3zmM1F3zz33RF1XV1fUcWLzTVQAAAAAAAAAAEChGaICAAAAAAAAAAAKzRAVAAAAAAAAAABQaIaoAAAAAAAAAACAQjNEBQAAAAAAAAAAFJohKgAAAAAAAAAAoNAMUQEAAAAAAAAAAIVmiAoAAAAAAAAAACg0Q1QAAAAAAAAAAECh1Y72CzjeDQ4ORt2GDRui7nOf+1zUzZs3L+qmTp0addXV2Tzd4cOHo2779u1R19HREXUDAwNRV2m9vb1Rt2XLlqhbs2ZN1E2aNCnq+vr6RmzWrl0bHSv9t5bL5aiDV0JNTU3UTZkyJerOOOOMqJs+fXrUpWtuqqenJ+rSNShdS9NrwtatW6Nu3759UXfgwIGo6+/vjzqOjvS6sH///qj75Cc/GXWlUinqXvva10bd2LFjR2xmzZoVHWv27NlRl/4bRkv6t033w+la8Mtf/jLqbr/99qh77LHHoi5dc+2Fji1DQ0NR9/TTT0fdX/3VX0Xd+973vqi7+OKLoy7d/zc2NkZdumdKDQ8PR116je7s7Iy6xx9/POruvPPOqPvJT34Sdel9avp7gWNduv9vaGiIunQNqvQ5tHDhwqi79NJLo27jxo1Rl96PHTx4MOrS30t6DUwd63tTjo50r7FkyZKou/rqq6Pu5JNPjrqWlpaoS59/pHvEL33pS1G3evXqqEv2Gul9VroWpF26BrkvoojSa+Wpp54adW9729uiLr1/+pu/+ZuKHg9OFOm1Ld2vd3d3R11dXV3UTZs2LerSfVV6f1dbW9kxkXTvsn79+qj7zGc+E3X33ntv1KUzDvY4VFX5JioAAAAAAAAAAKDgDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQakf7BRTF4OBg1O3bty/qDh48GHV1dXVRV12dzdMNDw9H3dDQUEW7crlc0a63tzfqOjs7o27//v1R197eHnXbtm2LuvHjx4/YrFu3LjpW+h6F0ZSuQQcOHIi65557LuoOHToUdR0dHVHX09MTdaVSKerSa0dNTU3UpWtfV1dX1HV3d0fdkSNHoi5d6zm2DAwMRN2WLVui7s///M+j7kc/+lHUXXfddSM2p512WnSsqVOnRl1tbbYVT9e+dH+TrmkbN26MukceeSTqHnzwwah78cUXoy7dV9njUFVVVdXf3x916fv5mWeeibpTTjkl6k4//fSoS9ehGTNmRF16X7lhw4aoS9fwTZs2RV16X5TuXdL7Tyia9JlQc3Nz1PX19UVdeo1Oz91x48ZF3aRJk6IuXdPS+7b0Pibd+1X6vqjSx0t/L6N1vBNF+ndLz6P0/n3v3r1Rl957pOtBund59NFHo+6b3/xm1D322GNRV8l7lErvWzxLgZcv3Wu8+93vjrqxY8dG3T/+4z9G3bPPPht16V4DThTpNXDnzp1R9/3vfz/qTjrppKibPHly1NXX10ddum9O91/pZ+Dpc/jbb7896tauXRt16f7VXojfh2+iAgAAAAAAAAAACs0QFQAAAAAAAAAAUGiGqAAAAAAAAAAAgEIzRAUAAAAAAAAAABSaISoAAAAAAAAAAKDQDFEBAAAAAAAAAACFZogKAAAAAAAAAAAoNENUAAAAAAAAAABAoRmiAgAAAAAAAAAACq1ULpfLo/KDS6XR+LEwqurq6qKura0t6lpbW0ds9u3bFx2rs7Mz6oaGhqIOXgnptSPtqquzWeKampqKHi9VW1tb0Z87ZsyYinYTJkyIunSrcfDgwair9Lo2PDwcdRyf0vOovr5+xKa5uTk6Vnq9T19bX19f1A0MDFT0eIODg1GX7g3Sc22Ubk/gFTFae5dKX9vS8zL9d6THsx7A0ZHuSWbPnh11t912W9S9+tWvjrqdO3dG3cqVKyvabd26NerS+450r5buwSq9Ro7WmlvpZ8Tp8dwHvrR0PRg3blzUzZs3L+oWLFgQdTt27Ii6zZs3R136HKK/vz/q7HHg+JQ++73gggui7mtf+1rUJc+iqqqqqm655ZaoW7VqVdT5jAdeWrqPHD9+fNRdd911UXfttddG3dy5c6Mu/fzkn//5n6Puvvvui7pdu3ZFXfps2n6dqqrR2zf7JioAAAAAAAAAAKDQDFEBAAAAAAAA/7927hhHcSAIw6g8EFhwTyJuwUm4AhfgSEgEgBG4N1ttNCqxjHrZ/724pPIkWNP+1AAA0URUAAAAAAAAAABANBEVAAAAAAAAAAAQTUQFAAAAAAAAAABEE1EBAAAAAAAAAADRRFQAAAAAAAAAAEA0ERUAAAAAAAAAABBNRAUAAAAAAAAAAEQbWmuty+Jh6LEW/itfX+/rIKs/BZ1+MoBvVN+pi8WiNDeOY2lutVqV5qqmaSrNXa/X0tz9fv+bxwEAAF5QPauo/h9TPYeY57k0BwDwp/V6XZrbbreluc1mU5o7HA6lud1uV5o7nU6lOd94APgUvd5ZbqICAAAAAAAAAACiiagAAAAAAAAAAIBoIioAAAAAAAAAACCaiAoAAAAAAAAAAIgmogIAAAAAAAAAAKKJqAAAAAAAAAAAgGgiKgAAAAAAAAAAIJqICgAAAAAAAAAAiCaiAgAAAAAAAAAAoi17PwDwunmeez8C8A9orZXmHo9Hae5yuZTmpmkqzVVV/47n8/nWvQAAwPs4qwAAPskwDKW56lno8Xgsze33+9Lc+XwuzVXPVgGA77mJCgAAAAAAAAAAiCaiAgAAAAAAAAAAoomoAAAAAAAAAACAaCIqAAAAAAAAAAAgmogKAAAAAAAAAACIJqICAAAAAAAAAACiiagAAAAAAAAAAIBoIioAAAAAAAAAACCaiAoAAAAAAAAAAIg2tNZal8XD0GMtAAAAAAAAQPl75TiOb917u91Kc50+4wJAd73egW6iAgAAAAAAAAAAoomoAAAAAAAAAACAaCIqAAAAAAAAAAAgmogKAAAAAAAAAACIJqICAAAAAAAAAACiiagAAAAAAAAAAIBoIioAAAAAAAAAACCaiAoAAAAAAAAAAIgmogIAAAAAAAAAAKINrbXWZfEw9FgLAAAAwA+onvV0OooCAAAA4EP0Oj9yExUAAAAAAAAAABBNRAUAAAAAAAAAAEQTUQEAAAAAAAAAANFEVAAAAAAAAAAAQDQRFQAAAAAAAAAAEE1EBQAAAAAAAAAARBNRAQAAAAAAAAAA0URUAAAAAAAAAABANBEVAAAAAAAAAAAQbdn7AQAAAAD4fK213o8AAAAAAC9zExUAAAAAAAAAABBNRAUAAAAAAAAAAEQTUQEAAAAAAAAAANFEVAAAAAAAAAAAQDQRFQAAAAAAAAAAEE1EBQAAAAAAAAAARBNRAQAAAAAAAAAA0URUAAAAAAAAAABANBEVAAAAAAAAAAAQbdlrcWut12oAAAAAAAAAAIDf3EQFAAAAAAAAAABEE1EBAAAAAAAAAADRRFQAAAAAAAAAAEA0ERUAAAAAAAAAABBNRAUAAAAAAAAAAEQTUQEAAAAAAAAAANFEVAAAAAAAAAAAQDQRFQAAAAAAAAAAEE1EBQAAAAAAAAAARBNRAQAAAAAAAAAA0URUAAAAAAAAAABANBEVAAAAAAAAAAAQTUQFAAAAAAAAAABEE1EBAAAAAAAAAADRRFQAAAAAAAAAAEA0ERUAAAAAAAAAABBNRAUAAAAAAAAAAEQTUQEAAAAAAAAAANFEVAAAAAAAAAAAQDQRFQAAAAAAAAAAEE1EBQAAAAAAAAAARBNRAQAAAAAAAAAA0URUAAAAAAAAAABANBEVAAAAAAAAAAAQTUQFAAAAAAAAAABEE1EBAAAAAAAAAADRRFQAAAAAAAAAAEA0ERUAAAAAAAAAABBNRAUAAAAAAAAAAET7BSUIkc3gq876AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 3000x900 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(\"=\"*60)\n",
+    "print(\"Visualizing Random Generation from Latent Space\")\n",
+    "print(\"=\"*60)\n",
+    "\n",
+    "vae.eval()\n",
+    "with torch.no_grad():\n",
+    "    n_samples = 16\n",
+    "    z = torch.randn(n_samples, latent_dim).to(device)\n",
+    "\n",
+    "    generated = vae.decode(z)\n",
+    "    generated_np = generated.cpu().numpy()\n",
+    "\n",
+    "    plot_results(generated, nrow=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8c808d0",
+   "metadata": {},
+   "source": [
+    "## β-VAE Experiments (Script Only)\n",
+    "\n",
+    "The cells below prepare end-to-end experiments for different values of the β coefficient.\n",
+    "Run them to compare reconstruction quality, sample diversity, and the balance between\n",
+    "reconstruction and KL losses across settings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a42ce672",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the β values you would like to explore\n",
+    "latent_dim = 128  # ensure consistency with the base experiment\n",
+    "beta_values = [0.5, 1.0, 3.0, 5.0]\n",
+    "\n",
+    "# Containers for results recorded during the experiments\n",
+    "experiment_histories = {}\n",
+    "experiment_summaries = {}\n",
+    "\n",
+    "# Prepare a test loader (shared across experiments)\n",
+    "test_dataset = datasets.MNIST('./data', train=False, download=True, transform=transform)\n",
+    "test_loader = DataLoader(test_dataset, batch_size=32, shuffle=True)\n",
+    "\n",
+    "for beta in beta_values:\n",
+    "    print(\"\n",
+    "\" + \"=\" * 60)\n",
+    "    print(f\"β-VAE Experiment (β={beta})\")\n",
+    "    print(\"=\" * 60)\n",
+    "\n",
+    "    vae = ConvVAE(latent_dim=latent_dim, img_channels=1)\n",
+    "    vae, history = train_conv_vae(vae, train_loader, epochs=40, device=device, beta=beta, lr=1e-3)\n",
+    "\n",
+    "    experiment_histories[beta] = history\n",
+    "\n",
+    "    final_recon = history['recon'][-1]\n",
+    "    final_kld = history['kld'][-1]\n",
+    "    ratio = final_recon / (final_kld + 1e-8)\n",
+    "\n",
+    "    print(f\"Final Reconstruction Loss: {final_recon:.4f}\")\n",
+    "    print(f\"Final KL Divergence:      {final_kld:.4f}\")\n",
+    "    print(f\"Recon/KL Ratio:           {ratio:.2f}\")\n",
+    "\n",
+    "    vae.eval()\n",
+    "    with torch.no_grad():\n",
+    "        batch, _ = next(iter(test_loader))\n",
+    "        batch = batch.to(device)\n",
+    "        recon_batch, _, _ = vae(batch)\n",
+    "\n",
+    "        plot_results(batch[:16], nrow=8, title=f'β={beta} • Original Samples')\n",
+    "        plot_results(recon_batch[:16], nrow=8, title=f'β={beta} • Reconstructions')\n",
+    "\n",
+    "        z = torch.randn(32, latent_dim).to(device)\n",
+    "        generated = vae.decode(z)\n",
+    "        plot_results(generated[:16], nrow=8, title=f'β={beta} • Random Generations')\n",
+    "\n",
+    "    experiment_summaries[beta] = {\n",
+    "        'final_recon': final_recon,\n",
+    "        'final_kld': final_kld,\n",
+    "        'ratio': ratio,\n",
+    "    }\n",
+    "\n",
+    "print(\"\n",
+    "Experiment summaries:\")\n",
+    "for beta, summary in experiment_summaries.items():\n",
+    "    print(f\"β={beta}: Recon={summary['final_recon']:.4f}, KL={summary['final_kld']:.4f}, Recon/KL={summary['ratio']:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "JfOlkPXKKKcU"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "A100",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
## Summary
- implement the convolutional VAE loss with mean-squared reconstruction and KL divergence terms
- extend the training utility to capture loss history for downstream analysis
- add scripted β-VAE experiment cells to compare reconstruction, sampling, and loss trade-offs across β values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6905a33ca3e8832087ce3d2324694cd4